### PR TITLE
(MAINT) Add Set Transport for PDB Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Binaries for programs and plugins
+.idea
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/puppetdb/client.go
+++ b/puppetdb/client.go
@@ -2,6 +2,7 @@ package puppetdb
 
 import (
 	"crypto/tls"
+	"net/http"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -17,7 +18,14 @@ func NewInsecureClient(hostURL, token string) *Client {
 	r.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	r.SetHostURL(hostURL)
 	r.SetHeader("X-Authentication", token)
+
 	return &Client{
 		resty: r,
 	}
+}
+
+// SetTransport lets the caller overwrite the default transport used by the client.
+// This is useful when injecting mock transports for testing purposes.
+func (c *Client) SetTransport(tripper http.RoundTripper) {
+	c.resty.SetTransport(tripper)
 }


### PR DESCRIPTION
This allows the user to override the default Transport
used by the HTTP client.
This is useful when using libraries such as go-vcr to inject
a fake transport.