### PR TITLE
Add support for the reports endpoint

### DIFF
--- a/puppetdb/reports.go
+++ b/puppetdb/reports.go
@@ -1,0 +1,114 @@
+package puppetdb
+
+import (
+	"time"
+)
+
+const (
+	reports = "/pdb/query/v4/reports"
+)
+
+// Puppet agent nodes submit reports after their runs, and the Puppet master forwards these to PuppetDB. Each report
+// includes:
+// Data about the entire run
+// Metadata about the report
+// Many events, describing what happened during the run
+func (c *Client) Reports(query string) (*[]Report, error) {
+	payload := &[]Report{}
+	err := getRequest(c, reports, query, payload)
+	return payload, err
+}
+
+// Report summaries for all event reports that matched the input parameters.
+type Report struct {
+	Hash                 string         `json:"hash"`
+	PuppetVersion        string         `json:"puppet_version"`
+	ReceiveTime          time.Time      `json:"receive_time"`
+	ReportFormat         int            `json:"report_format"`
+	StartTime            time.Time      `json:"start_time"`
+	EndTime              time.Time      `json:"end_time"`
+	ProducerTimestamp    time.Time      `json:"producer_timestamp"`
+	Producer             string         `json:"producer"`
+	TransactionUUID      string         `json:"transaction_uuid"`
+	Status               string         `json:"status"`
+	Noop                 bool           `json:"noop"`
+	NoopPending          bool           `json:"noop_pending"`
+	Environment          string         `json:"environment"`
+	ConfigurationVersion string         `json:"configuration_version"`
+	Certname             string         `json:"certname"`
+	CodeID               string         `json:"code_id"`
+	CatalogUUID          string         `json:"catalog_uuid"`
+	CachedCatalogStatus  string         `json:"cached_catalog_status"`
+	ResourceEvents       ResourceEvents `json:"resource_events"`
+	Resources            Resources      `json:"resources"`
+	Metrics              Metrics        `json:"metrics"`
+	Logs                 Logs           `json:"logs"`
+}
+
+// ResourceEvents ...
+type ResourceEvents struct {
+	Href string
+	Data []struct {
+		Status          string      `json:"status"`
+		Timestamp       time.Time   `json:"timestamp"`
+		ResourceType    string      `json:"resource_type"`
+		ResourceTitle   string      `json:"resource_title"`
+		Property        string      `json:"property"`
+		Name            string      `json:"name"`
+		NewValue        interface{} `json:"new_value"`
+		OldValue        interface{} `json:"old_value"`
+		Message         string      `json:"message"`
+		File            string      `json:"file"`
+		line            int         `json:"line"`
+		ContainmentPath []string    `json:"containment_path"`
+	}
+}
+
+// Resources ...
+type Resources struct {
+	Href string
+	Data []struct {
+		Timestamp       time.Time `json:"timestamp"`
+		ResourceType    string    `json:"resource_type"`
+		ResourceTitle   string    `json:"resource_title"`
+		ContainmentPath []string  `json:"containment_path"`
+		Skipped         bool      `json:"skipped"`
+		Events          []Event   `json:"events"`
+	}
+}
+
+// Event ...
+type Event struct {
+	Timestamp time.Time   `json:"timestamp"`
+	Property  string      `json:"property"`
+	Name      string      `json:"name"`
+	NewValue  interface{} `json:"new_value"`
+	OldValue  interface{} `json:"old_value"`
+	Message   string      `json:"message"`
+	Status    string      `json:"status"`
+}
+
+// Metrics ...
+type Metrics struct {
+	Href string
+	Data []struct {
+		Category string  `json:"category"`
+		Name     string  `json:"name"`
+		Value    float32 `json:"value"`
+	}
+}
+
+// Logs returns a single log line per data entry.
+// File and line may each be null if the log does not concern a resource.
+type Logs struct {
+	Href string
+	Data []struct {
+		File    string    `json:"file"`
+		Line    int       `json:"line"`
+		Level   string    `json:"level"`
+		Message string    `json:"message"`
+		Source  string    `json:"source"`
+		Tags    []string  `json:"tags"`
+		Time    time.Time `json:"time"`
+	}
+}

--- a/puppetdb/reports.go
+++ b/puppetdb/reports.go
@@ -59,7 +59,7 @@ type ResourceEvents struct {
 		OldValue        interface{} `json:"old_value"`
 		Message         string      `json:"message"`
 		File            string      `json:"file"`
-		line            int         `json:"line"`
+		Line            int         `json:"line"`
 		ContainmentPath []string    `json:"containment_path"`
 	}
 }

--- a/puppetdb/reports_test.go
+++ b/puppetdb/reports_test.go
@@ -1,0 +1,48 @@
+package puppetdb
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// TestReports performs a test on the Report endpoint and verifies the expected response is returned.
+func TestReports(t *testing.T) {
+	query := `["=", "certname", "foobar.delivery.puppetlabs.net"]`
+	setupGetResponder(t, reports, "query="+query, "reports.json")
+	actual, err := pdbClient.Reports(query)
+	require.Nil(t, err)
+	require.Equal(t, expectedReport, actual)
+}
+
+var expectedReport = &[]Report{{
+	Hash:                 "4324324324324324324",
+	PuppetVersion:        "10.0",
+	ReceiveTime:          time.Time{},
+	ReportFormat:         2.0,
+	StartTime:            time.Time{},
+	EndTime:              time.Time{},
+	ProducerTimestamp:    time.Time{},
+	Producer:             "foobar-master.puppet.com",
+	TransactionUUID:      "342343432432",
+	Status:               "Good",
+	Noop:                 false,
+	NoopPending:          false,
+	Environment:          "production",
+	ConfigurationVersion: "99",
+	Certname:             "foobar",
+	CodeID:               "2343",
+	CatalogUUID:          "343243243243243243",
+	CachedCatalogStatus:  "Good",
+	ResourceEvents: ResourceEvents{
+		Href: "http://foobar.events.com",
+	},
+	Resources: Resources{
+		Href: "http://foobar.resources.com",
+	},
+	Metrics: Metrics{
+		Href: "http://foobar.metrics.com",
+	},
+	Logs: Logs{
+		Href: "http://foobar.logs.com",
+	}}}

--- a/puppetdb/testdata/reports.json
+++ b/puppetdb/testdata/reports.json
@@ -1,0 +1,37 @@
+[{
+  "hash": "4324324324324324324",
+  "puppet_version": "10.0",
+  "receive_time": "0001-01-01T00:00:00Z",
+  "report_format": 2,
+  "start_time": "0001-01-01T00:00:00Z",
+  "end_time": "0001-01-01T00:00:00Z",
+  "producer_timestamp": "0001-01-01T00:00:00Z",
+  "producer": "foobar-master.puppet.com",
+  "transaction_uuid": "342343432432",
+  "status": "Good",
+  "noop": false,
+  "noop_pending": false,
+  "environment": "production",
+  "configuration_version": "99",
+  "certname": "foobar",
+  "code_id": "2343",
+  "catalog_uuid": "343243243243243243",
+  "cached_catalog_status": "Good",
+  "resource_events": {
+    "Href": "http://foobar.events.com",
+    "Data": null
+  },
+  "resources": {
+    "Href": "http://foobar.resources.com",
+    "Data": null
+  },
+  "metrics": {
+    "Href": "http://foobar.metrics.com",
+    "Data": null
+  },
+  "logs": {
+    "Href": "http://foobar.logs.com",
+    "Data": null
+  }
+}
+]


### PR DESCRIPTION
The report endpoint accepts the standard queries used by the API
i.e.
["=", "certname", "foobar.com"]