### PR TITLE
(MAINT) Add a count field to reports struct

### DIFF
--- a/pkg/puppetdb/reports.go
+++ b/pkg/puppetdb/reports.go
@@ -42,6 +42,7 @@ type Report struct {
 	Resources            Resources      `json:"resources"`
 	Metrics              Metrics        `json:"metrics"`
 	Logs                 Logs           `json:"logs"`
+	Count                int            `json:"count"`
 }
 
 // ResourceEvents ...


### PR DESCRIPTION
This will allow users to query for the total number of reports using "reports ["extract", [["function", "count"] ]]"