### PR TITLE
Use default GOPATH if none is defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 all: build test lint format tidy
 
+GOPATH := $(shell go env GOPATH)
+
 PHONY+= clean
 clean:
 	@echo "🔘 Cleaning build dir..."


### PR DESCRIPTION
The linter failed if no GOPATH was defined so define it when necessary.