### PR TITLE
Task metadata fixes

### DIFF
--- a/pkg/orch/tasks.go
+++ b/pkg/orch/tasks.go
@@ -60,23 +60,12 @@ type Task struct {
 		CodeID string `json:"code_id,omitempty"`
 	} `json:"environment,omitempty"`
 	Metadata struct {
-		Description  string `json:"description,omitempty"`
-		SupportsNoop bool   `json:"supports_noop,omitempty"`
-		InputMethod  string `json:"input_method,omitempty"`
-		Parameters   struct {
-			Name struct {
-				Description string `json:"description,omitempty"`
-				Type        string `json:"type,omitempty"`
-			} `json:"name,omitempty"`
-			Provider struct {
-				Description string `json:"description,omitempty"`
-				Type        string `json:"type,omitempty"`
-			} `json:"provider,omitempty"`
-			Version struct {
-				Description string `json:"description,omitempty"`
-				Type        string `json:"type,omitempty"`
-			} `json:"version,omitempty"`
-		} `json:"parameters,omitempty"`
+		Description     string                 `json:"description,omitempty"`
+		SupportsNoop    bool                   `json:"supports_noop,omitempty"`
+		InputMethod     string                 `json:"input_method,omitempty"`
+		Parameters      map[string]TaskParam   `json:"parameters,omitempty"`
+		Extensions      map[string]interface{} `json:"extensions,omitempty"`
+		Implementations []TaskImplementation   `json:"implementations"`
 	} `json:"metadata,omitempty"`
 	Files []struct {
 		Filename string `json:"filename,omitempty"`
@@ -89,4 +78,17 @@ type Task struct {
 		Sha256    string `json:"sha256,omitempty"`
 		SizeBytes int    `json:"size_bytes,omitempty"`
 	} `json:"files,omitempty"`
+}
+
+// TaskParam in the task metadata
+type TaskParam struct {
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+// TaskImplementation in the task metadata
+type TaskImplementation struct {
+	Name         string   `json:"name"`
+	Requirements []string `json:"requirements"`
+	InputMethod  string   `json:"input_method"`
 }

--- a/pkg/orch/tasks_test.go
+++ b/pkg/orch/tasks_test.go
@@ -54,46 +54,13 @@ var expectedTask = &Task{ID: "https://orchestrator.example.com:8143/orchestrator
 	Name   string "json:\"name,omitempty\""
 	CodeID string "json:\"code_id,omitempty\""
 }{Name: "production", CodeID: "urn:puppet:code-id:1:a86da166c30f871823f9b2ea224796e834840676;production"}, Metadata: struct {
-	Description  string "json:\"description,omitempty\""
-	SupportsNoop bool   "json:\"supports_noop,omitempty\""
-	InputMethod  string "json:\"input_method,omitempty\""
-	Parameters   struct {
-		Name struct {
-			Description string "json:\"description,omitempty\""
-			Type        string "json:\"type,omitempty\""
-		} "json:\"name,omitempty\""
-		Provider struct {
-			Description string "json:\"description,omitempty\""
-			Type        string "json:\"type,omitempty\""
-		} "json:\"provider,omitempty\""
-		Version struct {
-			Description string "json:\"description,omitempty\""
-			Type        string "json:\"type,omitempty\""
-		} "json:\"version,omitempty\""
-	} "json:\"parameters,omitempty\""
-}{Description: "Install a package", SupportsNoop: true, InputMethod: "stdin", Parameters: struct {
-	Name struct {
-		Description string "json:\"description,omitempty\""
-		Type        string "json:\"type,omitempty\""
-	} "json:\"name,omitempty\""
-	Provider struct {
-		Description string "json:\"description,omitempty\""
-		Type        string "json:\"type,omitempty\""
-	} "json:\"provider,omitempty\""
-	Version struct {
-		Description string "json:\"description,omitempty\""
-		Type        string "json:\"type,omitempty\""
-	} "json:\"version,omitempty\""
-}{Name: struct {
-	Description string "json:\"description,omitempty\""
-	Type        string "json:\"type,omitempty\""
-}{Description: "The package to install", Type: "String[1]"}, Provider: struct {
-	Description string "json:\"description,omitempty\""
-	Type        string "json:\"type,omitempty\""
-}{Description: "The provider to use to install the package", Type: "Optional[String[1]]"}, Version: struct {
-	Description string "json:\"description,omitempty\""
-	Type        string "json:\"type,omitempty\""
-}{Description: "The version of the package to install, defaults to latest", Type: "Optional[String[1]]"}}}, Files: []struct {
+	Description     string                 "json:\"description,omitempty\""
+	SupportsNoop    bool                   "json:\"supports_noop,omitempty\""
+	InputMethod     string                 "json:\"input_method,omitempty\""
+	Parameters      map[string]TaskParam   "json:\"parameters,omitempty\""
+	Extensions      map[string]interface{} "json:\"extensions,omitempty\""
+	Implementations []TaskImplementation   "json:\"implementations\""
+}{Description: "Bootstrap a node with puppet-agent", SupportsNoop: false, InputMethod: "stdin", Parameters: map[string]TaskParam{"cacert_content": TaskParam{Description: "The expected CA certificate content for the master", Type: "Optional[String]"}, "certname": TaskParam{Description: "The certname with which the node should be bootstrapped", Type: "Optional[String]"}, "custom_attribute": TaskParam{Description: "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml", Type: "Optional[Array[Pattern[/\\w+=\\w+/]]]"}, "dns_alt_names": TaskParam{Description: "The DNS alt names with which the agent certificate should be generated", Type: "Optional[String]"}, "environment": TaskParam{Description: "The environment in which the node should be bootstrapped", Type: "Optional[String]"}, "extension_request": TaskParam{Description: "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml", Type: "Optional[Array[Pattern[/\\w+=\\w+/]]]"}, "master": TaskParam{Description: "The fqdn of the master from which the puppet-agent should be bootstrapped", Type: "String"}, "set_noop": TaskParam{Description: "The noop setting in the [agent] section of puppet.conf", Type: "Optional[Boolean]"}}, Extensions: map[string]interface{}{"discovery": map[string]interface{}{"friendlyName": "Install Puppet agent", "parameters": map[string]interface{}{"cacert_content": map[string]interface{}{"placeholder": "-----BEGIN CERTIFICATE---- ... -----END CERTIFICATE-----"}, "master": map[string]interface{}{"placeholder": "master.company.net"}}, "puppetInstall": true, "type": []interface{}{"host"}}}, Implementations: []TaskImplementation{TaskImplementation{Name: "windows.ps1", Requirements: []string{"powershell"}, InputMethod: "powershell"}, TaskImplementation{Name: "linux.sh", Requirements: []string{"shell"}, InputMethod: "environment"}}}, Files: []struct {
 	Filename string "json:\"filename,omitempty\""
 	URI      struct {
 		Path   string "json:\"path,omitempty\""

--- a/pkg/orch/testdata/apidocs/task-response.json
+++ b/pkg/orch/testdata/apidocs/task-response.json
@@ -6,33 +6,87 @@
         "code_id": "urn:puppet:code-id:1:a86da166c30f871823f9b2ea224796e834840676;production"
     },
     "metadata": {
-        "description": "Install a package",
-        "supports_noop": true,
+        "description": "Bootstrap a node with puppet-agent",
         "input_method": "stdin",
         "parameters": {
-            "name": {
-                "description": "The package to install",
-                "type": "String[1]"
+            "master": {
+                "description": "The fqdn of the master from which the puppet-agent should be bootstrapped",
+                "type": "String"
             },
-            "provider": {
-                "description": "The provider to use to install the package",
-                "type": "Optional[String[1]]"
+            "cacert_content": {
+                "description": "The expected CA certificate content for the master",
+                "type": "Optional[String]"
             },
-            "version": {
-                "description": "The version of the package to install, defaults to latest",
-                "type": "Optional[String[1]]"
-            }
-        }
-    },
-    "files": [{
-        "filename": "install",
-        "uri": {
-            "path": "/package/tasks/install",
-            "params": {
-                "environment": "production"
+            "certname": {
+                "description": "The certname with which the node should be bootstrapped",
+                "type": "Optional[String]"
+            },
+            "environment": {
+                "description": "The environment in which the node should be bootstrapped",
+                "type": "Optional[String]"
+            },
+            "set_noop": {
+                "description": "The noop setting in the [agent] section of puppet.conf",
+                "type": "Optional[Boolean]"
+            },
+            "dns_alt_names": {
+                "description": "The DNS alt names with which the agent certificate should be generated",
+                "type": "Optional[String]"
+            },
+            "custom_attribute": {
+                "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
+                "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+            },
+            "extension_request": {
+                "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
+                "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
             }
         },
-        "sha256": "a9089b5b9720dca38a49db6f164cf8a053a7ea528711325da1c23de94672980f",
-        "size_bytes": 693
-    }]
+        "extensions": {
+            "discovery": {
+                "friendlyName": "Install Puppet agent",
+                "puppetInstall": true,
+                "type": [
+                    "host"
+                ],
+                "parameters": {
+                    "master": {
+                        "placeholder": "master.company.net"
+                    },
+                    "cacert_content": {
+                        "placeholder": "-----BEGIN CERTIFICATE---- ... -----END CERTIFICATE-----"
+                    }
+                }
+            }
+        },
+        "implementations": [
+            {
+                "name": "windows.ps1",
+                "requirements": [
+                    "powershell"
+                ],
+                "input_method": "powershell"
+            },
+            {
+                "name": "linux.sh",
+                "requirements": [
+                    "shell"
+                ],
+                "input_method": "environment"
+            }
+        ]
+    },
+    "files": [
+        {
+            "filename": "install",
+            "uri": {
+                "path": "/package/tasks/install",
+                "params": {
+                    "environment": "production"
+                }
+            },
+            "sha256": "a9089b5b9720dca38a49db6f164cf8a053a7ea528711325da1c23de94672980f",
+            "size_bytes": 693
+        }
+    ]
 }


### PR DESCRIPTION
The task metadata structs were specific to the "package" task and missed out a couple of other supported fields. This PR fixes up those problems.