### PR TITLE
Add the OrderBy clause to the reports, facts and inventory

### DIFF
--- a/cmd/puppetdb/pdb.go
+++ b/cmd/puppetdb/pdb.go
@@ -73,13 +73,13 @@ func execute(api string, query string, pagination puppetdb.Pagination, orderBy p
 		fmt.Printf("Nodes")
 		data, err = client.Nodes(query, &pagination, &orderBy)
 	case "facts":
-		data, err = client.Facts(query, &pagination)
+		data, err = client.Facts(query, &pagination, &orderBy)
 	case "inventory":
-		data, err = client.Inventory(query, &pagination)
+		data, err = client.Inventory(query, &pagination, &orderBy)
 	case "reports":
-		data, err = client.Reports(query, &pagination)
+		data, err = client.Reports(query, &pagination, &orderBy)
 	case "factnames":
-		data, err = client.FactNames(&pagination)
+		data, err = client.FactNames(&pagination, &orderBy)
 	}
 
 	if err != nil {

--- a/pkg/puppetdb/client.go
+++ b/pkg/puppetdb/client.go
@@ -34,14 +34,21 @@ func (c *Client) SetTransport(tripper http.RoundTripper) {
 // getRequest uses the Given client to make a HTTP GET request to the given path, providing
 // the query.  The result of the request is marshalled into the response type. e.g.
 // var payload *[]Fact
-// getRequest(client, "/pdb/query/v4/facts", query, &payload)
-func getRequest(client *Client, path string, query string, pagination *Pagination, response interface{}) error {
+// getRequest(client, "/pdb/query/v4/facts",
+//				query,
+//				&Pagination{Limit: 10, Offset: 20},
+//				&OrderBy{Field: "certname", Order: "asc",},
+//				&payload)
+func getRequest(client *Client, path string, query string, pagination *Pagination, orderBy *OrderBy, response interface{}) error {
 	req := client.resty.R().SetResult(&response)
 	if query != "" {
 		req.SetQueryParam("query", query)
 	}
 	if pagination != nil {
 		req.SetQueryParams(pagination.toParams())
+	}
+	if orderBy != nil {
+		req.SetQueryParams(orderBy.toParams())
 	}
 	r, err := req.Get(path)
 	if err != nil {

--- a/pkg/puppetdb/facts.go
+++ b/pkg/puppetdb/facts.go
@@ -1,21 +1,21 @@
 package puppetdb
 
 const (
-	factnames = "/pdb/query/v4/fact-names"
+	factNames = "/pdb/query/v4/fact-names"
 	facts     = "/pdb/query/v4/facts"
 )
 
 // FactNames will return an alphabetical list of all known fact names, including those which are known only for deactivated nodes.
-func (c *Client) FactNames(pagination *Pagination) ([]string, error) {
+func (c *Client) FactNames(pagination *Pagination, orderBy *OrderBy) ([]string, error) {
 	payload := []string{}
-	err := getRequest(c, factnames, "", pagination, &payload)
+	err := getRequest(c, factNames, "", pagination, orderBy, &payload)
 	return payload, err
 }
 
 // Facts will return all facts matching the given query. Facts for deactivated nodes are not included in the response.
-func (c *Client) Facts(query string, pagination *Pagination) ([]Fact, error) {
+func (c *Client) Facts(query string, pagination *Pagination, orderBy *OrderBy) ([]Fact, error) {
 	payload := []Fact{}
-	err := getRequest(c, facts, query, pagination, &payload)
+	err := getRequest(c, facts, query, pagination, orderBy, &payload)
 	return payload, err
 }
 
@@ -29,4 +29,5 @@ type Fact struct {
 	Value       interface{} `json:"value"`
 	Certname    string      `json:"certname"`
 	Environment string      `json:"environment"`
+	Count       int         `json:"count"`
 }

--- a/pkg/puppetdb/facts_test.go
+++ b/pkg/puppetdb/facts_test.go
@@ -9,8 +9,8 @@ import (
 // TestFactNames performs a test on the FactNames endpoint and verifies the expected response is returned.
 func TestFactNames(t *testing.T) {
 	// Test FactNames
-	setupGetResponder(t, factnames, "", "factnames-response.json")
-	actual, err := pdbClient.FactNames(nil)
+	setupGetResponder(t, factNames, "", "factnames-response.json")
+	actual, err := pdbClient.FactNames(nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, expectedFactNames, actual)
 }
@@ -20,7 +20,7 @@ func TestFacts(t *testing.T) {
 	// Test with query
 	query := `["=", "certname", "foobar.puppetlabs.net"]`
 	setupGetResponder(t, facts, "query="+query, "facts-response.json")
-	actual, err := pdbClient.Facts(query, nil)
+	actual, err := pdbClient.Facts(query, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, expectedFacts, actual)
 }

--- a/pkg/puppetdb/inventory.go
+++ b/pkg/puppetdb/inventory.go
@@ -6,9 +6,9 @@ const (
 
 // Inventory enables an alternative query syntax for digging into structured facts, and can be used instead of the facts,
 // fact-contents, and factsets endpoints for most fact-related queries.
-func (c *Client) Inventory(query string, pagination *Pagination) ([]Inventory, error) {
+func (c *Client) Inventory(query string, pagination *Pagination, orderBy *OrderBy) ([]Inventory, error) {
 	payload := []Inventory{}
-	err := getRequest(c, inventory, query, pagination, &payload)
+	err := getRequest(c, inventory, query, pagination, orderBy, &payload)
 	return payload, err
 }
 
@@ -19,4 +19,5 @@ type Inventory struct {
 	Environment string                 `json:"environment"`
 	Facts       map[string]interface{} `json:"facts"`
 	Trusted     map[string]interface{} `json:"trusted"`
+	Count       int                    `json:"count"`
 }

--- a/pkg/puppetdb/inventory_test.go
+++ b/pkg/puppetdb/inventory_test.go
@@ -10,7 +10,7 @@ import (
 func TestInventory(t *testing.T) {
 	query := `["=", "certname", "foobar.delivery.puppetlabs.net"]`
 	setupGetResponder(t, inventory, "query="+query, "inventory.json")
-	actual, err := pdbClient.Inventory(query, nil)
+	actual, err := pdbClient.Inventory(query, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, expectedInventory, actual)
 }

--- a/pkg/puppetdb/nodes.go
+++ b/pkg/puppetdb/nodes.go
@@ -1,29 +1,12 @@
 package puppetdb
 
-import "fmt"
+const nodes = "/pdb/query/v4/nodes"
 
 // Nodes will return all nodes matching the given query. Deactivated and expired nodes aren’t included in the response.
 func (c *Client) Nodes(query string, pagination *Pagination, orderBy *OrderBy) ([]Node, error) {
 	payload := []Node{}
-	req := c.resty.R().SetResult(&payload)
-	if query != "" {
-		req.SetQueryParam("query", query)
-	}
-	if pagination != nil {
-		req.SetQueryParams(pagination.toParams())
-	}
-	if orderBy != nil {
-		req.SetQueryParams(orderBy.toParams())
-	}
-
-	r, err := req.Get("/pdb/query/v4/nodes")
-	if err != nil {
-		return nil, err
-	}
-	if r.IsError() {
-		return nil, fmt.Errorf("%s: %s", r.Status(), r.Body())
-	}
-	return payload, nil
+	err := getRequest(c, nodes, query, pagination, orderBy, &payload)
+	return payload, err
 }
 
 // Node is a PuppetDB node

--- a/pkg/puppetdb/reports.go
+++ b/pkg/puppetdb/reports.go
@@ -12,9 +12,9 @@ const (
 // Data about the entire run
 // Metadata about the report
 // Many events, describing what happened during the run
-func (c *Client) Reports(query string, pagination *Pagination) ([]Report, error) {
+func (c *Client) Reports(query string, pagination *Pagination, orderBy *OrderBy) ([]Report, error) {
 	payload := []Report{}
-	err := getRequest(c, reports, query, pagination, &payload)
+	err := getRequest(c, reports, query, pagination, orderBy, &payload)
 	return payload, err
 }
 

--- a/pkg/puppetdb/reports_test.go
+++ b/pkg/puppetdb/reports_test.go
@@ -11,7 +11,7 @@ import (
 func TestReports(t *testing.T) {
 	query := `["=", "certname", "foobar.delivery.puppetlabs.net"]`
 	setupGetResponder(t, reports, "query="+query, "reports.json")
-	actual, err := pdbClient.Reports(query, nil)
+	actual, err := pdbClient.Reports(query, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, expectedReport, actual)
 }


### PR DESCRIPTION
requests.
Users can now supply an optional OrderBy i.e.

```
        &OrderBy{Field: "certname", Order: "asc"}
```

* refactor the nodes method to use the same getRequest as the other
API call.
* add count field to facts,reports and inventory to capture the response
when count() is used in a query.