### PR TITLE
Unwrap URL errors after PuppetDB calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,7 @@ func main() {
 	pdbClient := puppetdb.NewInsecureClient(pdbHostURL, token)
 	orchHostURL := "https://" + peServer + ":8143"
 	orchClient := orch.NewInsecureClient(orchHostURL, token)
-	fmt.Println("Connecting to: ", peServer)
+	fmt.Println("Connecting to:", peServer)
 
 	nodes, err := pdbClient.Nodes("", nil, nil)
 	if err != nil {


### PR DESCRIPTION
Checks for a URL error and pulls out the underlying problem to clean up our errors. Also consistent error messaging for both HTTP errors and PuppetDB errors (like 404).