### PR TITLE
(SEN-3868) Force user to specify TLS config plus other lint/security fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,18 +37,22 @@ format:
 PHONY+= lint
 lint: $(GOPATH)/bin/golangci-lint
 	@echo "🔘 Linting $(1) (`date '+%H:%M:%S'`)"
+	@lint=`golint ./...`; \
+	if [ "$$lint" != "" ]; \
+	then echo "🔴 Lint found by golint"; echo "$$lint"; exit 1;\
+	fi
 	@lint=`golangci-lint run`; \
 	if [ "$$lint" != "" ]; \
-	then echo "🔴 Lint found"; echo "$$lint"; exit 1;\
-	else echo "✅ Lint-free (`date '+%H:%M:%S'`)"; \
+	then echo "🔴 Lint found by golangci-lint"; echo "$$lint"; exit 1;\
 	fi
+	@echo "✅ Lint-free (`date '+%H:%M:%S'`)"
 
 PHONY+= sec
 sec: $(GOPATH)/bin/gosec
 	@echo "🔘 Checking for security problems ... (`date '+%H:%M:%S'`)"
 	@sec=`gosec -quiet ./...`; \
 	if [ "$$sec" != "" ]; \
-	then echo "🔴 Problems found"; echo "$$sec";\
+	then echo "🔴 Problems found"; echo "$$sec"; exit 1;\
 	else echo "✅ No problems found (`date '+%H:%M:%S'`)"; \
 	fi
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -18,9 +19,9 @@ func main() {
 	peServer := os.Args[1]
 	token := os.Args[2]
 	pdbHostURL := "https://" + peServer + ":8081"
-	pdbClient := puppetdb.NewInsecureClient(pdbHostURL, token)
+	pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	orchHostURL := "https://" + peServer + ":8143"
-	orchClient := orch.NewInsecureClient(orchHostURL, token)
+	orchClient := orch.NewClient(orchHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	fmt.Println("Connecting to:", peServer)
 
 	nodes, err := pdbClient.Nodes("", nil, nil)

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -13,16 +13,18 @@ import (
 	"github.com/puppetlabs/go-pe-client/pkg/puppetdb"
 )
 
+// InitHistoryFile ...
 func InitHistoryFile() (*os.File, error) {
 	usr, err := user.Current()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get users home directory.   The command history wont be saved.")
+		return nil, fmt.Errorf("unable to get users home directory - the command history wont be saved")
 	}
 
 	filename := fmt.Sprintf("%s/.pdb_history", usr.HomeDir)
-	return os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0655)
+	return os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0600)
 }
 
+// WriteHistory ...
 func WriteHistory(historyFile *os.File, cmd string) error {
 	if historyFile != nil {
 		_, err := historyFile.WriteString(fmt.Sprintf("%s\n", cmd))
@@ -33,6 +35,7 @@ func WriteHistory(historyFile *os.File, cmd string) error {
 	return nil
 }
 
+// ReadHistory ...
 func ReadHistory(historyFile *os.File) []string {
 	var lines []string
 	if historyFile != nil {
@@ -45,6 +48,7 @@ func ReadHistory(historyFile *os.File) []string {
 	return lines
 }
 
+// PrintString ...
 func PrintString(data interface{}) {
 	jsonString, err := json.MarshalIndent(data, "", "\t")
 	if err != nil {

--- a/pkg/orch/client.go
+++ b/pkg/orch/client.go
@@ -14,10 +14,12 @@ type Client struct {
 	strict bool
 }
 
-// NewInsecureClient access the orchestrator API in an insecure manner
-func NewInsecureClient(hostURL, token string) *Client {
+// NewClient access the orchestrator API via TLS
+func NewClient(hostURL, token string, tlsConfig *tls.Config) *Client {
 	r := resty.New()
-	r.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	if tlsConfig != nil {
+		r.SetTLSClientConfig(tlsConfig)
+	}
 	r.SetHostURL(hostURL)
 	r.SetHeader("X-Authentication", token)
 	r.SetError(OrchestratorError{})

--- a/pkg/orch/common_test.go
+++ b/pkg/orch/common_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	orchClient = NewInsecureClient(orchHostURL, "xxxx")
+	orchClient = NewClient(orchHostURL, "xxxx", nil)
 	orchClient.strict = true
 	httpmock.Activate()
 	httpmock.ActivateNonDefault(orchClient.resty.GetClient())

--- a/pkg/puppetdb/client.go
+++ b/pkg/puppetdb/client.go
@@ -8,9 +8,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
 )
 
 // Client for the Orchestrator API
@@ -18,16 +17,15 @@ type Client struct {
 	resty *resty.Client
 }
 
-// NewInsecureClient access the orchestrator API in an insecure manner
-func NewInsecureClient(hostURL, token string) *Client {
+// NewClient access the orchestrator API via TLS
+func NewClient(hostURL, token string, tlsConfig *tls.Config) *Client {
 	r := resty.New()
-	r.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	if tlsConfig != nil {
+		r.SetTLSClientConfig(tlsConfig)
+	}
 	r.SetHostURL(hostURL)
 	r.SetHeader("X-Authentication", token)
-
-	return &Client{
-		resty: r,
-	}
+	return &Client{resty: r}
 }
 
 // SetTransport lets the caller overwrite the default transport used by the client.

--- a/pkg/puppetdb/common_test.go
+++ b/pkg/puppetdb/common_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	pdbClient = NewInsecureClient(hostURL, "xxxx")
+	pdbClient = NewClient(hostURL, "xxxx", nil)
 	httpmock.Activate()
 	httpmock.ActivateNonDefault(pdbClient.resty.GetClient())
 }


### PR DESCRIPTION
Replace NewInsecureClient with NewClient and force users to provide their own TLS config. That means the caller has responsibiity for deciding whether secure/insecure is the right approach in their context.

Move test main.go into its own subdir to make it clear its not related to the puppetdb cli tool.

Enable golint and fix up a few small lint errors.

Fix up remaining gosec issues and enable build failures if others are found in the future.

Fixes:

[/Users/scott/github/go-pe-client/cmd/puppetdb/pdb.go:132] - G307 (CWE-): Deferring unsafe method "*os.File" on type "Close" (Confidence: HIGH, Severity: MEDIUM)
  > defer historyFile.Close()

[/Users/scott/github/go-pe-client/internal/cli/helpers.go:23] - G302 (CWE-276): Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
  > os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0655)