### PR TITLE
Add support for plans in orchestrator

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -154,4 +154,15 @@ func main() {
 	spew.Dump(jobNodes)
 	fmt.Println()
 
+	tasks, err := orchClient.Tasks("production")
+	if err != nil {
+		panic(err)
+	}
+	spew.Dump(tasks)
+
+	plans, err := orchClient.Plans("production")
+	if err != nil {
+		panic(err)
+	}
+	spew.Dump(plans)
 }

--- a/pkg/orch/plans.go
+++ b/pkg/orch/plans.go
@@ -1,0 +1,100 @@
+package orch
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	orchPlans    = "/orchestrator/v1/plans"
+	orchPlanName = "/orchestrator/v1/plans/{module}/{planname}"
+)
+
+var plansRegex = regexp.MustCompile(`http.*\/orchestrator\/v1\/plans\/(.*)/(.*)`)
+
+// Plans lists all known plans in a given environment (GET /plans)
+func (c *Client) Plans(environment string) (*Plans, error) {
+	payload := &Plans{}
+	req := c.resty.R().SetResult(payload)
+	if environment != "" {
+		req.SetQueryParam("environment", environment)
+	}
+	r, err := req.Get(orchPlans)
+	if err != nil {
+		return nil, err
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, r.Error().(error)
+		}
+		return nil, fmt.Errorf("%s error: %s", orchPlans, r.Status())
+	}
+	return payload, nil
+}
+
+// PlanByID extracts the module and planname from the supplied ID and calls Plan(...)
+func (c *Client) PlanByID(environment, planID string) (*Plan, error) {
+	results := plansRegex.FindStringSubmatch(planID)
+	if len(results) != 3 {
+		return nil, fmt.Errorf("unknown plan ID format: %s", planID)
+	}
+	module := results[1]
+	planname := results[2]
+	return c.Plan(environment, module, planname)
+}
+
+// Plan returns data about the specified plan, including metadata (GET /plans/:module/:planname)
+func (c *Client) Plan(environment, module, planname string) (*Plan, error) {
+	payload := &Plan{}
+	req := c.resty.R().
+		SetResult(payload).
+		SetPathParams(map[string]string{
+			"module":   module,
+			"planname": planname,
+		})
+	if environment != "" {
+		req.SetQueryParam("environment", environment)
+	}
+	r, err := req.Get(orchPlanName)
+	if err != nil {
+		return nil, err
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, r.Error().(error)
+		}
+		replacer := strings.NewReplacer("{module}", module, "{planname}", planname)
+		return nil, fmt.Errorf("%s error: %s", replacer.Replace(orchPlanName), r.Status())
+	}
+	return payload, nil
+}
+
+// Plans lists the known plans in a single environment
+type Plans struct {
+	Environment struct {
+		Name   string `json:"name,omitempty"`
+		CodeID string `json:"code_id,omitempty"`
+	} `json:"environment,omitempty"`
+	Items []struct {
+		ID        string `json:"id,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Permitted bool   `json:"permitted,omitempty"`
+	} `json:"items,omitempty"`
+}
+
+// Plan contains information about a specific plan
+type Plan struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Environment struct {
+		Name   string `json:"name,omitempty"`
+		CodeID string `json:"code_id,omitempty" structs:"-"`
+	} `json:"environment,omitempty"`
+	Metadata  PlanMetadata `json:"metadata,omitempty"`
+	Permitted bool         `json:"permitted,omitempty"`
+}
+
+// PlanMetadata (always an empty object)
+type PlanMetadata struct {
+}

--- a/pkg/orch/plans.go
+++ b/pkg/orch/plans.go
@@ -91,10 +91,6 @@ type Plan struct {
 		Name   string `json:"name,omitempty"`
 		CodeID string `json:"code_id,omitempty" structs:"-"`
 	} `json:"environment,omitempty"`
-	Metadata  PlanMetadata `json:"metadata,omitempty"`
-	Permitted bool         `json:"permitted,omitempty"`
-}
-
-// PlanMetadata (always an empty object)
-type PlanMetadata struct {
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	Permitted bool                   `json:"permitted,omitempty"`
 }

--- a/pkg/orch/plans_test.go
+++ b/pkg/orch/plans_test.go
@@ -1,0 +1,83 @@
+package orch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/fatih/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlans(t *testing.T) {
+
+	// Test without environment
+	setupGetResponder(t, orchPlans, "", "plans-response.json")
+	actual, err := orchClient.Plans("")
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test with environment
+	setupGetResponder(t, orchPlans, "environment=myenv", "plans-response.json")
+	actual, err = orchClient.Plans("myenv")
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test error
+	setupErrorResponder(t, orchPlans)
+	actual, err = orchClient.Plans("")
+	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+
+}
+
+func TestPlan(t *testing.T) {
+
+	replacer := strings.NewReplacer("{module}", "package", "{planname}", "install")
+	orchPlanPackageInstall := replacer.Replace(orchPlanName)
+
+	// Test without environment
+	setupGetResponder(t, orchPlanPackageInstall, "", "plan-response.json")
+	actual, err := orchClient.Plan("", "package", "install")
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test with environment
+	setupGetResponder(t, orchPlanPackageInstall, "environment=myenv", "plan-response.json")
+	actual, err = orchClient.Plan("myenv", "package", "install")
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test error
+	setupErrorResponder(t, orchPlanPackageInstall)
+	actual, err = orchClient.Plan("myenv", "package", "install")
+	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+
+}
+
+func TestPlanByID(t *testing.T) {
+	replacer := strings.NewReplacer("{module}", "package", "{planname}", "upgrade")
+	orchPlanPackageUpgrade := replacer.Replace(orchPlanName)
+
+	id := "https://orchestrator.example.com:8143" + orchPlanPackageUpgrade
+
+	// Test without environment
+	setupGetResponder(t, orchPlanPackageUpgrade, "", "plan-response.json")
+	actual, err := orchClient.PlanByID("", id)
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test with environment
+	setupGetResponder(t, orchPlanPackageUpgrade, "environment=myenv", "plan-response.json")
+	actual, err = orchClient.PlanByID("myenv", id)
+	require.Nil(t, err)
+	require.False(t, structs.HasZero(actual), spew.Sdump(actual))
+
+	// Test error
+	setupErrorResponder(t, orchPlanPackageUpgrade)
+	actual, err = orchClient.PlanByID("myenv", id)
+	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+
+}

--- a/pkg/orch/testdata/apidocs/plan-response.json
+++ b/pkg/orch/testdata/apidocs/plan-response.json
@@ -1,0 +1,10 @@
+{
+    "id": "https://orchestrator.example.com:8143/orchestrator/v1/plans/package/install",
+    "name": "canary::random",
+    "environment": {
+      "name": "production",
+      "code_id": null
+    },
+    "metadata": {},
+    "permitted": true
+  }

--- a/pkg/orch/testdata/apidocs/plans-response.json
+++ b/pkg/orch/testdata/apidocs/plans-response.json
@@ -1,0 +1,22 @@
+{
+    "environment": {
+        "name": "production",
+        "code_id": "null"
+    },
+    "items": [{
+        "id": "https://orchestrator.example.com:8143/orchestrator/v1/plans/profile/firewall",
+        "name": "profile::firewall",
+        "permitted": true
+      },
+      {
+        "id": "https://orchestrator.example.com:8143/orchestrator/v1/plans/profile/rolling_update",
+        "name": "profile::rolling_update",
+        "permitted": true
+      },
+      {
+        "id": "https://orchestrator.example.com:8143/orchestrator/v1/plans/canary/random",
+        "name": "canary::random",
+        "permitted": false
+      }
+    ]
+}


### PR DESCRIPTION
Adding support for plans in orchestrator as defined at https://puppet.com/docs/pe/latest/orchestrator_api_plans_endpoint.html