### PR TITLE
Changed type of plan metadata

### DIFF
--- a/pkg/orch/plans.go
+++ b/pkg/orch/plans.go
@@ -74,7 +74,7 @@ func (c *Client) Plan(environment, module, planname string) (*Plan, error) {
 type Plans struct {
 	Environment struct {
 		Name   string `json:"name,omitempty"`
-		CodeID string `json:"code_id,omitempty"`
+		CodeID string `json:"code_id,omitempty" structs:"-"`
 	} `json:"environment,omitempty"`
 	Items []struct {
 		ID        string `json:"id,omitempty"`
@@ -91,6 +91,6 @@ type Plan struct {
 		Name   string `json:"name,omitempty"`
 		CodeID string `json:"code_id,omitempty" structs:"-"`
 	} `json:"environment,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
-	Permitted bool                   `json:"permitted,omitempty"`
+	Metadata  TaskMetadata `json:"metadata,omitempty" structs:"-"`
+	Permitted bool         `json:"permitted,omitempty"`
 }

--- a/pkg/orch/testdata/apidocs/plan-response.json
+++ b/pkg/orch/testdata/apidocs/plan-response.json
@@ -3,8 +3,21 @@
     "name": "canary::random",
     "environment": {
       "name": "production",
-      "code_id": null
+      "code_id": ""
     },
-    "metadata": {},
+    "metadata": {
+      "description": "A plan that prints basic OS information for the specified targets. It first\nruns the facts task to retrieve facts from the targets, then compiles the\ndesired OS information from the os fact value of each targets.\n\nThe $targets parameter is a list of the targets for which to print the OS\ninformation. This plan primarily provides readable formatting, and ignores\ntargets that error.",
+      "private": false,
+      "supports_noop": false,
+      "input_method": "",
+      "parameters": {
+       "targets": {
+        "description": "",
+        "type": "TargetSpec"
+       }
+      },
+      "extensions": null,
+      "implementations": null
+    },
     "permitted": true
   }

--- a/pkg/orch/testdata/apidocs/plans-response.json
+++ b/pkg/orch/testdata/apidocs/plans-response.json
@@ -1,7 +1,7 @@
 {
     "environment": {
         "name": "production",
-        "code_id": "null"
+        "code_id": ""
     },
     "items": [{
         "id": "https://orchestrator.example.com:8143/orchestrator/v1/plans/profile/firewall",


### PR DESCRIPTION
Plan metadata is not always an empty object as the documentation suggests.