### PR TITLE
Classifer Groups Query

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/puppetlabs/go-pe-client/pkg/classifier"
 	"os"
 
 	"github.com/davecgh/go-spew/spew"
@@ -53,6 +54,8 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 	pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	orchHostURL := "https://" + peServer + ":8143"
 	orchClient := orch.NewClient(orchHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
+	classifierHostURL := "https://" + peServer + ":4433"
+	classifierClient := classifier.NewClient(classifierHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	fmt.Println("Connecting to:", peServer)
 
 	nodes, err := pdbClient.Nodes("", nil, nil)
@@ -196,4 +199,11 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 		panic(err)
 	}
 	spew.Dump(plans)
+
+	groups, err := classifierClient.Groups(nil)
+	if err != nil {
+		panic(err)
+	}
+	spew.Dump(groups)
+	fmt.Println()
 }

--- a/pkg/classifier/client.go
+++ b/pkg/classifier/client.go
@@ -1,0 +1,64 @@
+package classifier
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	"net/http"
+	"net/url"
+)
+
+// Client for the Orchestrator API
+type Client struct {
+	resty *resty.Client
+}
+
+// NewClient access the orchestrator API via TLS
+func NewClient(hostURL, token string, tlsConfig *tls.Config) *Client {
+	r := resty.New()
+	if tlsConfig != nil {
+		r.SetTLSClientConfig(tlsConfig)
+	}
+	r.SetHostURL(hostURL)
+	r.SetHeader("X-Authentication", token)
+	return &Client{resty: r}
+}
+
+// SetTransport lets the caller overwrite the default transport used by the client.
+// This is useful when injecting mock transports for testing purposes.
+func (c *Client) SetTransport(tripper http.RoundTripper) {
+	c.resty.SetTransport(tripper)
+}
+
+// getRequest uses the Given client to make a HTTP GET request to the given path, providing
+// the query.  The result of the request is marshalled into the response type. e.g.
+// var payload *[]Group
+// getRequest(client, "/classifier/v1/groups",
+//				&Pagination{Limit: 10, Offset: 20},
+//				&payload)
+func getRequest(client *Client, path string, pagination *Pagination, response interface{}) error {
+	req := client.resty.R().SetResult(&response)
+
+	if pagination != nil {
+		req.SetQueryParams(pagination.toParams())
+	}
+
+	r, err := req.Get(path)
+	if err != nil {
+		var ue *url.Error
+		if errors.As(err, &ue) {
+			return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, ue.Err)
+		}
+		return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, err)
+	}
+	if r.IsError() {
+		re := r.Error()
+		if re == nil {
+			return fmt.Errorf("%s %s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
+		}
+		return fmt.Errorf("%s %s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
+	}
+
+	return nil
+}

--- a/pkg/classifier/groups.go
+++ b/pkg/classifier/groups.go
@@ -1,0 +1,42 @@
+package classifier
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	groups = "/classifier-api/v1/groups"
+)
+
+// Groups will return all groups.
+func (c *Client) Groups(pagination *Pagination) ([]Group, error) {
+	payload := []Group{}
+	err := getRequest(c, groups, pagination, &payload)
+	return payload, err
+}
+
+// Group will return the group matching the given id.
+func (c *Client) Group(id string) (Group, error) {
+	payload := Group{}
+	err := getRequest(c, fmt.Sprintf("%s/%s", groups, id), nil, &payload)
+	return payload, err
+}
+
+// Group represents a group returned by the groups endpoint.
+// See https://puppet.com/docs/pe/2018.1/groups_endpoint.html#get_v1_groups__response_format
+type Group struct {
+	ID                string
+	Name              string
+	Description       string
+	Environment       string
+	EnvironmentTrumps bool `json:"environment_trumps"`
+	Parent            string
+	Rule              interface{}
+	Classes           map[string]interface{}
+	ConfigData        map[string]interface{} `json:"config_data"`
+	Deleted           map[string]interface{}
+	Variables         map[string]interface{}
+	LastEdited        time.Time `json:"last_edited"`
+	SerialNumber      int       `json:"serial_number"`
+}

--- a/pkg/classifier/groups_test.go
+++ b/pkg/classifier/groups_test.go
@@ -1,0 +1,84 @@
+package classifier
+
+import (
+	"fmt"
+	"github.com/jarcoal/httpmock"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	pdbClient = NewClient(hostURL, "xxxx", nil)
+	httpmock.Activate()
+	httpmock.ActivateNonDefault(pdbClient.resty.GetClient())
+}
+
+func TestGroups(t *testing.T) {
+	setupGetResponder(t, groups, "", "groups-response.json")
+	actual, err := pdbClient.Groups(nil)
+	require.Nil(t, err)
+	require.True(t, len(actual) == 2)
+	require.Equal(t, expected, actual)
+}
+
+func TestGroup(t *testing.T) {
+	setupGetResponder(t, fmt.Sprintf("%s/%s", groups, g2ID), "", "group.json")
+	actual, err := pdbClient.Group(g2ID)
+	require.Nil(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, g2, actual)
+}
+
+func setupGetResponder(t *testing.T, url, query, responseFilename string) {
+	httpmock.Reset()
+	responseBody, err := ioutil.ReadFile("testdata/" + responseFilename)
+	require.Nil(t, err)
+	response := httpmock.NewBytesResponse(200, responseBody)
+	response.Header.Set("Content-Type", "application/json")
+	if query != "" {
+		httpmock.RegisterResponder(http.MethodGet, hostURL+url, httpmock.ResponderFromResponse(response))
+	} else {
+		httpmock.RegisterResponderWithQuery(http.MethodGet, hostURL+url, query, httpmock.ResponderFromResponse(response))
+	}
+}
+
+var pdbClient *Client
+var hostURL = "https://test-host:4433"
+
+var g = Group{
+	Parent:            "5239b6da-8194-4f99-ab37-de6cbf665754",
+	EnvironmentTrumps: false,
+	Name:              "PE Infrastructure Agent",
+	Rule:              []interface{}{"and", []interface{}{"~", []interface{}{"fact", "pe_server_version"}, ".+"}},
+	Variables:         map[string]interface{}{},
+	ID:                "799ab2fb-5ece-4628-ac47-ba61e70d5b54",
+	Environment:       "production",
+	LastEdited:        time.Time{},
+	SerialNumber:      1,
+	Classes:           map[string]interface{}{"puppet_enterprise::profile::agent": map[string]interface{}{}},
+	ConfigData:        map[string]interface{}{},
+}
+
+var g2ID = "913e54b7-b09c-4543-9f74-daff5e51a49f"
+var g2 = Group{
+	Parent:            "d1fc626d-222a-4616-be89-cc67ef1f8b3a",
+	Description:       "Production nodes",
+	EnvironmentTrumps: true,
+	Name:              "Production environment",
+	Rule:              []interface{}{"and", []interface{}{"=", []interface{}{"trusted", "extensions", "pp_environment"}, "production"}},
+	Variables:         map[string]interface{}{},
+	ID:                g2ID,
+	Environment:       "production",
+	LastEdited:        time.Time{},
+	SerialNumber:      1,
+	Classes:           map[string]interface{}{},
+	ConfigData:        map[string]interface{}{},
+	Deleted:           map[string]interface{}(nil),
+}
+var expected = []Group{
+	g, g2,
+}

--- a/pkg/classifier/pagination.go
+++ b/pkg/classifier/pagination.go
@@ -1,0 +1,22 @@
+package classifier
+
+import "strconv"
+
+//toParams will take the Pagination struct and convert into a form Client SetQueryParam accepts
+func (p Pagination) toParams() map[string]string {
+	params := map[string]string{}
+	if p.Limit > 0 {
+		params["limit"] = strconv.Itoa(p.Limit)
+	}
+	if p.Offset > 0 {
+		params["offset"] = strconv.Itoa(p.Offset)
+	}
+
+	return params
+}
+
+// Pagination is a filter to be used when paginating
+type Pagination struct {
+	Limit  int
+	Offset int
+}

--- a/pkg/classifier/testdata/group.json
+++ b/pkg/classifier/testdata/group.json
@@ -1,0 +1,24 @@
+{
+  "description": "Production nodes",
+  "parent": "d1fc626d-222a-4616-be89-cc67ef1f8b3a",
+  "environment_trumps": true,
+  "name": "Production environment",
+  "rule": [
+    "and",
+    [
+      "=",
+      [
+        "trusted",
+        "extensions",
+        "pp_environment"
+      ],
+      "production"
+    ]
+  ],
+  "variables": {},
+  "id": "913e54b7-b09c-4543-9f74-daff5e51a49f",
+  "environment": "production",
+  "serial_number": 1,
+  "classes": {},
+  "config_data": {}
+}

--- a/pkg/classifier/testdata/groups-response.json
+++ b/pkg/classifier/testdata/groups-response.json
@@ -1,0 +1,51 @@
+[
+  {
+    "parent": "5239b6da-8194-4f99-ab37-de6cbf665754",
+    "environment_trumps": false,
+    "name": "PE Infrastructure Agent",
+    "rule": [
+      "and",
+      [
+        "~",
+        [
+          "fact",
+          "pe_server_version"
+        ],
+        ".+"
+      ]
+    ],
+    "variables": {},
+    "id": "799ab2fb-5ece-4628-ac47-ba61e70d5b54",
+    "environment": "production",
+    "serial_number": 1,
+    "classes": {
+      "puppet_enterprise::profile::agent": {}
+    },
+    "config_data": {}
+  },
+  {
+    "description": "Production nodes",
+    "parent": "d1fc626d-222a-4616-be89-cc67ef1f8b3a",
+    "environment_trumps": true,
+    "name": "Production environment",
+    "rule": [
+      "and",
+      [
+        "=",
+        [
+          "trusted",
+          "extensions",
+          "pp_environment"
+        ],
+        "production"
+      ]
+    ],
+    "variables": {},
+    "id": "913e54b7-b09c-4543-9f74-daff5e51a49f",
+    "environment": "production",
+    "serial_number": 1,
+    "classes": {},
+    "config_data": {}
+  }
+]
+


### PR DESCRIPTION
The classifier can be queried for all groups and for a specific group.
The group names are required for estate reporting filters.