### PR TITLE
(LIDAR-338) Add timeout to PDB client.

### DIFF
--- a/cmd/puppetdb/pdb.go
+++ b/cmd/puppetdb/pdb.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	prompt "github.com/c-bata/go-prompt"
 	"github.com/puppetlabs/go-pe-client/internal/cli"
@@ -16,6 +17,7 @@ import (
 var client *puppetdb.Client
 var prompter *prompt.Prompt
 var historyFile *os.File
+var pdbTimeout = time.Second * 30
 
 var suggestions = []prompt.Suggest{
 	//  Methods
@@ -112,7 +114,7 @@ func processArgs() (*puppetdb.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	pdb := puppetdb.NewClient(u.String(), token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this tool is private and for development purpose
+	pdb := puppetdb.NewClient(u.String(), token, &tls.Config{InsecureSkipVerify: true}, pdbTimeout) // #nosec - this tool is private and for development purpose
 	return pdb, nil
 }
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -4,14 +4,16 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
-
-	"github.com/puppetlabs/go-pe-client/pkg/classifier"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/puppetlabs/go-pe-client/pkg/classifier"
 	"github.com/puppetlabs/go-pe-client/pkg/orch"
 	"github.com/puppetlabs/go-pe-client/pkg/puppetdb"
 	"github.com/puppetlabs/go-pe-client/pkg/rbac"
 )
+
+var pdbTimeout = time.Second * 30
 
 func tokenGesture(peServer string, login string, password string) {
 	rbacHostURL := "https://" + peServer + ":4433"
@@ -93,7 +95,7 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 		peServer := os.Args[3]
 		token := os.Args[4]
 		pdbHostURL := "https://" + peServer + ":8081"
-		pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
+		pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}, pdbTimeout) // #nosec - this main() is private and for development purpose
 
 		nodes, err := pdbClient.Nodes("", nil, nil)
 		if err != nil {
@@ -115,7 +117,7 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 	peServer := os.Args[1]
 	token := os.Args[2]
 	pdbHostURL := "https://" + peServer + ":8081"
-	pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
+	pdbClient := puppetdb.NewClient(pdbHostURL, token, &tls.Config{InsecureSkipVerify: true}, pdbTimeout) // #nosec - this main() is private and for development purpose
 	orchHostURL := "https://" + peServer + ":8143"
 	orchClient := orch.NewClient(orchHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	classifierHostURL := "https://" + peServer + ":4433"

--- a/pkg/puppetdb/client.go
+++ b/pkg/puppetdb/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
@@ -17,14 +18,17 @@ type Client struct {
 	resty *resty.Client
 }
 
-// NewClient access the orchestrator API via TLS
-func NewClient(hostURL, token string, tlsConfig *tls.Config) *Client {
+// NewClient access the orchestrator API via TLS. N.B. The timeout is the resty http client timeout so is all encompassing
+// and will incorporate connect, TLS handshake, http/s header receipt and general data transfer. The value used for this in
+// ER is 5 seconds which seems reasonable.
+func NewClient(hostURL, token string, tlsConfig *tls.Config, timeout time.Duration) *Client {
 	r := resty.New()
 	if tlsConfig != nil {
 		r.SetTLSClientConfig(tlsConfig)
 	}
 	r.SetHostURL(hostURL)
 	r.SetHeader("X-Authentication", token)
+	r.SetTimeout(timeout)
 	return &Client{resty: r}
 }
 

--- a/pkg/puppetdb/common_test.go
+++ b/pkg/puppetdb/common_test.go
@@ -4,13 +4,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
 )
 
 func init() {
-	pdbClient = NewClient(hostURL, "xxxx", nil)
+	pdbClient = NewClient(hostURL, "xxxx", nil, time.Second*1000)
 	httpmock.Activate()
 	httpmock.ActivateNonDefault(pdbClient.resty.GetClient())
 }


### PR DESCRIPTION
Problem:
----------
An issue has occurred on estate reporting where an entire request times out if any PDB is unresponsive. 

Solution:
---------
Make it mandatory to pass a timeout to the PDB client on instantiation.

Testing:
--------
Tested with estate reporting with dial timeouts and timeouts when dial has worked but subsequently we are sending / receiving data. Both timeout at the configured time.