### PR TITLE
Initial support for PE root API

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/puppetlabs/go-pe-client/pkg/classifier"
 	"github.com/puppetlabs/go-pe-client/pkg/orch"
+	"github.com/puppetlabs/go-pe-client/pkg/pe"
 	"github.com/puppetlabs/go-pe-client/pkg/puppetdb"
 	"github.com/puppetlabs/go-pe-client/pkg/rbac"
 )
@@ -122,7 +123,16 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 	orchClient := orch.NewClient(orchHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	classifierHostURL := "https://" + peServer + ":4433"
 	classifierClient := classifier.NewClient(classifierHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
+	peHostURL := "https://" + peServer
+	peClient := pe.NewClient(peHostURL, token, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 	fmt.Println("Connecting to:", peServer)
+
+	environments, err := peClient.Environments()
+	if err != nil {
+		panic(err)
+	}
+	spew.Dump(environments)
+	fmt.Println()
 
 	nodes, err := pdbClient.Nodes("", nil, nil)
 	if err != nil {

--- a/pkg/pe/client.go
+++ b/pkg/pe/client.go
@@ -1,0 +1,34 @@
+package pe
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// Client for the PE API
+type Client struct {
+	resty  *resty.Client
+	strict bool
+}
+
+// NewClient access the PE API via TLS
+func NewClient(hostURL string, token string, tlsConfig *tls.Config) *Client {
+	r := resty.New()
+	if tlsConfig != nil {
+		r.SetTLSClientConfig(tlsConfig)
+	}
+	r.SetHostURL(hostURL)
+	r.SetHeader("X-Authentication", token)
+	client := Client{resty: r}
+	r.JSONUnmarshal = func(data []byte, v interface{}) error {
+		d := json.NewDecoder(bytes.NewReader(data))
+		if client.strict {
+			d.DisallowUnknownFields()
+		}
+		return d.Decode(v)
+	}
+	return &client
+}

--- a/pkg/pe/common_test.go
+++ b/pkg/pe/common_test.go
@@ -1,0 +1,35 @@
+package pe
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	peClient = NewClient(peHostURL, "xxxx", nil)
+	peClient.strict = true
+	httpmock.Activate()
+	httpmock.ActivateNonDefault(peClient.resty.GetClient())
+}
+
+func setupGetResponder(t *testing.T, url, query, responseFilename string) {
+	httpmock.Reset()
+	responseBody, err := ioutil.ReadFile("testdata/apidocs/" + responseFilename)
+	require.Nil(t, err)
+	response := httpmock.NewBytesResponse(200, responseBody)
+	response.Header.Set("Content-Type", "application/json")
+	if query != "" {
+		httpmock.RegisterResponder(http.MethodGet, peHostURL+url, httpmock.ResponderFromResponse(response))
+	} else {
+		httpmock.RegisterResponderWithQuery(http.MethodGet, peHostURL+url, query, httpmock.ResponderFromResponse(response))
+	}
+	response.Body.Close()
+}
+
+var peClient *Client
+
+var peHostURL = "https://test-host"

--- a/pkg/pe/environments.go
+++ b/pkg/pe/environments.go
@@ -1,0 +1,27 @@
+package pe
+
+import (
+	"fmt"
+)
+
+const (
+	apiEnvironments = "/api/environments"
+)
+
+// Environments gets the list of environments from the PE API (GET /api/environments)
+func (c *Client) Environments() ([]string, error) {
+	payload := []string{}
+	r, err := c.resty.R().
+		SetResult(&payload).
+		Get(apiEnvironments)
+	if err != nil {
+		return nil, err
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, r.Error().(error)
+		}
+		return nil, fmt.Errorf("%s error: %s", apiEnvironments, r.Status())
+	}
+	return payload, nil
+}

--- a/pkg/pe/environments_test.go
+++ b/pkg/pe/environments_test.go
@@ -1,0 +1,19 @@
+package pe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironments(t *testing.T) {
+
+	// Test without environment
+	setupGetResponder(t, apiEnvironments, "", "environments.json")
+	actual, err := peClient.Environments()
+	require.Nil(t, err)
+	require.Equal(t, expectedEnvironments, actual)
+
+}
+
+var expectedEnvironments = []string{"production", "test"}

--- a/pkg/pe/testdata/apidocs/environments.json
+++ b/pkg/pe/testdata/apidocs/environments.json
@@ -1,0 +1,4 @@
+[
+  "production",
+  "test"
+]


### PR DESCRIPTION
Add the root PE API i.e. https://mype.puppetlabs.net/api/...

Right now only environments are supported.