### PR TITLE
(CISC-849) Update node classifier error handling

### DIFF
--- a/pkg/classifier/node.go
+++ b/pkg/classifier/node.go
@@ -13,10 +13,13 @@ const (
 // certname is the hostname of the node to query.
 func (c *Client) Node(certname string) (Node, error) {
 	payload, err := PostRequest(c, fmt.Sprintf("%s/%s", uri, certname))
-	var node Node
-	if err := json.Unmarshal(payload, &node); err != nil {
-		panic(err)
+
+	if err != nil {
+		return Node{}, err
 	}
+
+	var node Node
+	err = json.Unmarshal(payload, &node)
 	return node, err
 }
 


### PR DESCRIPTION
When node classifier executes request to API, the response is not checked for an error.

Additionally, the json.Unmarshal throws a panic unnecessarily instead of just returning
the error.