### PR TITLE
(MAINT) Path should be []interface not []string

### DIFF
--- a/pkg/puppetdb/facts.go
+++ b/pkg/puppetdb/facts.go
@@ -44,6 +44,7 @@ type Fact struct {
 // Path ([]string): an array of the parts that make up the path
 // Type (string): the type of the fact, string, integer etc
 type FactPath struct {
-	Path []string `json:"path"`
-	Type string   `json:"type"`
+	Name string        `json:"name"`
+	Path []interface{} `json:"path"`
+	Type string        `json:"type"`
 }

--- a/pkg/puppetdb/facts_test.go
+++ b/pkg/puppetdb/facts_test.go
@@ -35,7 +35,7 @@ func TestFacts(t *testing.T) {
 }
 
 var expectedFactNames = []string{"agent_canary", "agent_specified_environment", "aio_agent_build", "aio_agent_version"}
-var expectedFactPaths = []FactPath{{Path: []string{"partitions", "sda3", "mount"}, Type: "string"}, {Path: []string{"partitions", "sda3", "size"}, Type: "string"}, {Path: []string{"partitions", "sda3", "uuid"}, Type: "string"}}
+var expectedFactPaths = []FactPath{{Path: []interface{}{"partitions", "sda3", "mount"}, Type: "string"}, {Path: []interface{}{"partitions", "sda3", "size"}, Type: "string"}, {Path: []interface{}{"partitions", "sda3", "uuid"}, Type: "string"}, {Path: []interface{}{"apt_package_dist_updates", float64(90)}, Type: "string"}}
 var expectedFacts = []Fact{
 	{Name: "id", Value: "root", Certname: "foobar.puppetlabs.net", Environment: "production"},
 	{Name: "os", Value: map[string]interface{}{"architecture": "x86_64", "distro": map[string]interface{}{"codename": "Core", "description": "CentOS Linux release 7.4.1708 (Core)", "id": "CentOS", "release": map[string]interface{}{"full": "7.4.1708", "major": "7", "minor": "4"}, "specification": ":core-4.1-amd64:core-4.1-noarch"}, "family": "RedHat", "hardware": "x86_64", "name": "CentOS", "release": map[string]interface{}{"full": "7.4.1708", "major": "7", "minor": "4"}, "selinux": map[string]interface{}{"config_mode": "permissive", "config_policy": "targeted", "current_mode": "permissive", "enabled": true, "enforced": false, "policy_version": "28"}}, Certname: "foobar.puppetlabs.net", Environment: "production"},

--- a/pkg/puppetdb/testdata/factpaths-response.json
+++ b/pkg/puppetdb/testdata/factpaths-response.json
@@ -7,4 +7,7 @@
 }, {
   "path" : [ "partitions", "sda3", "uuid" ],
   "type" : "string"
+}, {
+  "type" : "string",
+  "path" : ["apt_package_dist_updates",90]
 } ]


### PR DESCRIPTION
This changes the type of path from []string to []interface.
Valid Path values can be a slice of any JSON type e.g. both
these are valid:

```
{
  "path" : [ "partitions", "sda3", "uuid" ],
  "type" : "string"
}, {
  "type" : "string",
  "path" : ["apt_package_dist_updates",90]
}
```