### PR TITLE
(MAINT) Add the count field to the factpaths type

### DIFF
--- a/pkg/puppetdb/facts.go
+++ b/pkg/puppetdb/facts.go
@@ -44,7 +44,8 @@ type Fact struct {
 // Path ([]string): an array of the parts that make up the path
 // Type (string): the type of the fact, string, integer etc
 type FactPath struct {
-	Name string        `json:"name"`
-	Path []interface{} `json:"path"`
-	Type string        `json:"type"`
+	Name  string        `json:"name"`
+	Path  []interface{} `json:"path"`
+	Type  string        `json:"type"`
+	Count int           `json:"count"`
 }


### PR DESCRIPTION
FactPaths can return a count, so this adds the field to
the struct, so that the data can successfully be unmarshalled.