### PR TITLE
(CISC-1061) Return a specific error when the job isn't found in PE.

### DIFF
--- a/pkg/orch/common_test.go
+++ b/pkg/orch/common_test.go
@@ -60,8 +60,12 @@ func setupPostResponder(t *testing.T, url, requestFilename, responseFilename str
 }
 
 func setupErrorResponder(t *testing.T, url string) {
+	setupResponderWithStatusCode(t, url, http.StatusBadRequest)
+}
+
+func setupResponderWithStatusCode(t *testing.T, url string, statusCode int) {
 	httpmock.Reset()
-	responder, err := httpmock.NewJsonResponder(400, expectedError)
+	responder, err := httpmock.NewJsonResponder(statusCode, expectedError)
 	require.Nil(t, err)
 	httpmock.RegisterResponder(http.MethodGet, orchHostURL+url, responder)
 	httpmock.RegisterResponder(http.MethodPost, orchHostURL+url, responder)

--- a/pkg/orch/jobs_test.go
+++ b/pkg/orch/jobs_test.go
@@ -1,6 +1,8 @@
 package orch
 
 import (
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -40,6 +42,13 @@ func TestJob(t *testing.T) {
 	actual, err = orchClient.Job("123")
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
+	require.False(t, errors.Is(err, ErrJobNotFound))
+
+	//test job not found
+	setupResponderWithStatusCode(t, testURL, http.StatusNotFound)
+	actual, err = orchClient.Job("123")
+	require.Nil(t, actual)
+	require.True(t, errors.Is(err, ErrJobNotFound))
 
 }
 
@@ -58,6 +67,13 @@ func TestJobReport(t *testing.T) {
 	actual, err = orchClient.JobReport("123")
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
+	require.False(t, errors.Is(err, ErrJobNotFound))
+
+	//test job report not found
+	setupResponderWithStatusCode(t, testURL, http.StatusNotFound)
+	actual, err = orchClient.JobReport("123")
+	require.Nil(t, actual)
+	require.True(t, errors.Is(err, ErrJobNotFound))
 
 }
 
@@ -76,5 +92,12 @@ func TestJobNodes(t *testing.T) {
 	actual, err = orchClient.JobNodes("123")
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
+	require.False(t, errors.Is(err, ErrJobNotFound))
+
+	//test job report not found
+	setupResponderWithStatusCode(t, testURL, http.StatusNotFound)
+	actual, err = orchClient.JobNodes("123")
+	require.Nil(t, actual)
+	require.True(t, errors.Is(err, ErrJobNotFound))
 
 }


### PR DESCRIPTION
Problem:
----------
Compliance keeps it's own internal store of job ids. This has the potential to get out of sync with PE job store.

Solution:
----------
(Arguably there is a bigger solution). Send a specific error on return when the job is not found. This means that a caller can distinguish between errors when a job is not found.

Testing:
---------
- Added unit tests.
- Tested against a live PE and behaves as expected in unit tests etc.