### PR TITLE
(CISC-1167) Return Status Codes on needed statements (job, CommandTas…

### DIFF
--- a/pkg/orch/client.go
+++ b/pkg/orch/client.go
@@ -36,8 +36,9 @@ func NewClient(hostURL string, token string, tlsConfig *tls.Config) *Client {
 
 // OrchestratorError represents an error response from the Orchestrator API
 type OrchestratorError struct {
-	Kind string `json:"kind"`
-	Msg  string `json:"msg"`
+	Kind       string `json:"kind"`
+	Msg        string `json:"msg"`
+	StatusCode int
 }
 
 func (oe *OrchestratorError) Error() string {

--- a/pkg/orch/command.go
+++ b/pkg/orch/command.go
@@ -21,13 +21,13 @@ func (c *Client) CommandTask(taskRequest *TaskRequest) (*JobID, error) {
 		SetBody(taskRequest).
 		Post(orchCommandTask)
 	if err != nil {
-		return nil, err
+		return nil, FormatOrchError(r, err.Error())
 	}
 	if r.IsError() {
 		if r.Error() != nil {
-			return nil, r.Error().(error)
+			return nil, FormatOrchError(r)
 		}
-		return nil, fmt.Errorf("%s error: %s", orchCommandTask, r.Status())
+		return nil, FormatOrchError(r)
 	}
 	return &payload, nil
 }
@@ -56,13 +56,13 @@ func (c *Client) CommandScheduleTask(scheduleTaskRequest *ScheduleTaskRequest) (
 		SetBody(scheduleTaskRequest).
 		Post(orchCommandScheduleTask)
 	if err != nil {
-		return nil, err
+		return nil, FormatOrchError(r, err.Error())
 	}
 	if r.IsError() {
 		if r.Error() != nil {
-			return nil, r.Error().(error)
+			return nil, FormatOrchError(r)
 		}
-		return nil, fmt.Errorf("%s error: %s", orchCommandScheduleTask, r.Status())
+		return nil, FormatOrchError(r)
 	}
 	return &payload, nil
 }

--- a/pkg/orch/common_test.go
+++ b/pkg/orch/common_test.go
@@ -76,6 +76,13 @@ var orchClient *Client
 var orchHostURL = "https://test-host:8143"
 
 var expectedError = &OrchestratorError{
-	Kind: "puppetlabs.orchestrator/unknown-environment",
-	Msg:  "Unknown environment doesnotexist",
+	Kind:       "puppetlabs.orchestrator/unknown-environment",
+	Msg:        "Unknown environment doesnotexist",
+	StatusCode: 400,
+}
+
+var expectedJobNotFoundErr = &OrchestratorError{
+	Kind:       "puppetlabs.orchestrator/unknown-environment",
+	Msg:        "/orchestrator/v1/jobs/123 error: job not found",
+	StatusCode: 404,
 }

--- a/pkg/orch/jobs.go
+++ b/pkg/orch/jobs.go
@@ -61,10 +61,10 @@ func (c *Client) Job(jobID string) (*Job, error) {
 		SetPathParams(map[string]string{"job-id": jobID}).
 		Get(orchJob)
 	if err != nil {
-		return nil, err
+		return nil, FormatOrchError(r, err.Error())
 	}
 	if err = processJobResponse(r, strings.ReplaceAll(orchJob, "{job-id}", jobID)); err != nil {
-		return nil, err
+		return nil, FormatOrchError(r, err.Error())
 	}
 
 	return payload, nil

--- a/pkg/orch/jobs_test.go
+++ b/pkg/orch/jobs_test.go
@@ -42,14 +42,13 @@ func TestJob(t *testing.T) {
 	actual, err = orchClient.Job("123")
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
-	require.False(t, errors.Is(err, ErrJobNotFound))
+	require.False(t, errors.Is(err, expectedJobNotFoundErr))
 
 	//test job not found
 	setupResponderWithStatusCode(t, testURL, http.StatusNotFound)
 	actual, err = orchClient.Job("123")
 	require.Nil(t, actual)
-	require.True(t, errors.Is(err, ErrJobNotFound))
-
+	require.Equal(t, err, expectedJobNotFoundErr)
 }
 
 func TestJobReport(t *testing.T) {

--- a/pkg/orch/utils.go
+++ b/pkg/orch/utils.go
@@ -1,0 +1,31 @@
+package orch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// FormatOrchError takes the resty response and a possible resty err and tries to create an
+// OrchestratorError with as much info as possible
+func FormatOrchError(r *resty.Response, customError ...string) error {
+
+	orchErr, ok := r.Error().(*OrchestratorError)
+
+	if !ok {
+		return fmt.Errorf("unable to unmarshal an OrchestratorError, StatusCode: %s", r.Status())
+	}
+
+	if len(customError) > 0 {
+		orchErr.Msg = strings.Join(customError, ", ")
+	}
+
+	x := &OrchestratorError{
+		StatusCode: r.StatusCode(),
+		Kind:       orchErr.Kind,
+		Msg:        orchErr.Msg,
+	}
+
+	return x
+}


### PR DESCRIPTION
…k, CommandScheduledTask)

On the compilance team we need to get back the statusCodes from the resty client, this pr sets up a OrchestratorError that can be returned containing the StatusCodes, Msg and Kind. 