### PR TITLE
(CISC-1167) Return error with HTTP status code.

### DIFF
--- a/pkg/orch/client.go
+++ b/pkg/orch/client.go
@@ -37,10 +37,30 @@ func NewClient(hostURL string, token string, tlsConfig *tls.Config) *Client {
 // OrchestratorError represents an error response from the Orchestrator API
 type OrchestratorError struct {
 	Kind       string `json:"kind"`
-	Msg        string `json:"msg"`
+	Msg        string `json:"Msg"`
 	StatusCode int
 }
 
 func (oe *OrchestratorError) Error() string {
 	return oe.Msg
+}
+
+// GetStatusCode will return the status code.
+func (oe *OrchestratorError) GetStatusCode() int {
+	return oe.StatusCode
+}
+
+// HTTPError represents an error with the HTTP response code
+type HTTPError struct {
+	Msg        string
+	StatusCode int
+}
+
+func (he *HTTPError) Error() string {
+	return he.Msg
+}
+
+// GetStatusCode will return the HTTP status code.
+func (he *HTTPError) GetStatusCode() int {
+	return he.StatusCode
 }

--- a/pkg/orch/command.go
+++ b/pkg/orch/command.go
@@ -21,13 +21,13 @@ func (c *Client) CommandTask(taskRequest *TaskRequest) (*JobID, error) {
 		SetBody(taskRequest).
 		Post(orchCommandTask)
 	if err != nil {
-		return nil, FormatOrchError(r, err.Error())
+		return nil, FormatError(r, err.Error())
 	}
 	if r.IsError() {
 		if r.Error() != nil {
-			return nil, FormatOrchError(r)
+			return nil, FormatError(r)
 		}
-		return nil, FormatOrchError(r)
+		return nil, FormatError(r)
 	}
 	return &payload, nil
 }
@@ -56,13 +56,13 @@ func (c *Client) CommandScheduleTask(scheduleTaskRequest *ScheduleTaskRequest) (
 		SetBody(scheduleTaskRequest).
 		Post(orchCommandScheduleTask)
 	if err != nil {
-		return nil, FormatOrchError(r, err.Error())
+		return nil, FormatError(r, err.Error())
 	}
 	if r.IsError() {
 		if r.Error() != nil {
-			return nil, FormatOrchError(r)
+			return nil, FormatError(r)
 		}
-		return nil, FormatOrchError(r)
+		return nil, FormatError(r)
 	}
 	return &payload, nil
 }

--- a/pkg/orch/command_test.go
+++ b/pkg/orch/command_test.go
@@ -1,8 +1,10 @@
 package orch
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,11 +31,23 @@ func TestCommandTask(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, expectedCommandTaskResponse, actual)
 
-	// Test error
+	// Test Orchestrator error
 	setupErrorResponder(t, orchCommandTask)
 	actual, err = orchClient.CommandTask(taskRequest)
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
+
+	// Test HTTP error
+	setupResponderWithStatusCodeAndBody(t, orchCommandTask, http.StatusBadRequest, []byte(`{"StatusCode": 400}`))
+	actual, err = orchClient.CommandTask(taskRequest)
+	assert.Error(t, err)
+	require.Nil(t, actual)
+	testExpectError := getExpectedHTTPError(http.StatusBadRequest, "ignorefornow")
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Error("Error returned is not of type HTTP error.")
+	}
+	require.Equal(t, httpErr.StatusCode, testExpectError.StatusCode)
 
 }
 
@@ -67,6 +81,25 @@ func TestCommandScheduleTask(t *testing.T) {
 	setupErrorResponder(t, orchCommandScheduleTask)
 	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
 	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+
+	// Test HTTP error
+	setupResponderWithStatusCodeAndBody(t, orchCommandScheduleTask, http.StatusBadRequest, []byte(`{"StatusCode": 400}`))
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	assert.Error(t, err)
+	require.Nil(t, actual)
+	testExpectError := getExpectedHTTPError(http.StatusBadRequest, "ignorefornow")
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Error("Error returned is not of type HTTP error.")
+	}
+	require.Equal(t, httpErr.StatusCode, testExpectError.StatusCode)
+
+	//Test Orchestrator error
+	setupErrorResponder(t, orchCommandScheduleTask)
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	require.Nil(t, actual)
+	assert.Error(t, err)
 	require.Equal(t, expectedError, err)
 }
 

--- a/pkg/orch/common_test.go
+++ b/pkg/orch/common_test.go
@@ -64,11 +64,22 @@ func setupErrorResponder(t *testing.T, url string) {
 }
 
 func setupResponderWithStatusCode(t *testing.T, url string, statusCode int) {
+	setupResponderWithStatusCodeAndBody(t, url, statusCode, expectedError)
+}
+
+func setupResponderWithStatusCodeAndBody(t *testing.T, url string, statusCode int, response interface{}) {
 	httpmock.Reset()
-	responder, err := httpmock.NewJsonResponder(statusCode, expectedError)
+	responder, err := httpmock.NewJsonResponder(statusCode, response)
 	require.Nil(t, err)
 	httpmock.RegisterResponder(http.MethodGet, orchHostURL+url, responder)
 	httpmock.RegisterResponder(http.MethodPost, orchHostURL+url, responder)
+}
+
+func getExpectedHTTPError(statusCode int, msg string) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		Msg:        msg,
+	}
 }
 
 var orchClient *Client

--- a/pkg/orch/jobs.go
+++ b/pkg/orch/jobs.go
@@ -61,10 +61,10 @@ func (c *Client) Job(jobID string) (*Job, error) {
 		SetPathParams(map[string]string{"job-id": jobID}).
 		Get(orchJob)
 	if err != nil {
-		return nil, FormatOrchError(r, err.Error())
+		return nil, FormatError(r, err.Error())
 	}
 	if err = processJobResponse(r, strings.ReplaceAll(orchJob, "{job-id}", jobID)); err != nil {
-		return nil, FormatOrchError(r, err.Error())
+		return nil, FormatError(r, err.Error())
 	}
 
 	return payload, nil

--- a/pkg/orch/jobs_test.go
+++ b/pkg/orch/jobs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/structs"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +50,18 @@ func TestJob(t *testing.T) {
 	actual, err = orchClient.Job("123")
 	require.Nil(t, actual)
 	require.Equal(t, err, expectedJobNotFoundErr)
+
+	//Test HTTP error
+	setupResponderWithStatusCodeAndBody(t, testURL, http.StatusBadRequest, []byte(`{"StatusCode": 400}`))
+	actual, err = orchClient.Job("123")
+	assert.Error(t, err)
+	require.Nil(t, actual)
+	testExpectError := getExpectedHTTPError(http.StatusBadRequest, "ignorefornow")
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Error("Error returned is not of type HTTP error.")
+	}
+	require.Equal(t, httpErr.StatusCode, testExpectError.StatusCode)
 }
 
 func TestJobReport(t *testing.T) {


### PR DESCRIPTION
Problem:
---------
When we have a HTTP error code then this should be able to be returned as part of the error from our APIs.

Solution:
----------
Extend current orchestrator error to add the status code and in the case of having a HTTP error but being unable to get an orchestrator error then return a http error. In the case where there is no http response just return a normal error (string).

Testing:
---------
Unit tests added.

(I still want to reproduce the non orchestrator error if possible so don't merge just yet)