### PR TITLE
(CISC-1277) Unable to set enforce_environment false

### DIFF
--- a/pkg/orch/command.go
+++ b/pkg/orch/command.go
@@ -189,7 +189,7 @@ type DeployRequest struct {
 	Noop               bool   `json:"noop,omitempty"`
 	NoNoop             bool   `json:"no_noop,omitempty"`
 	Concurrency        int    `json:"concurrency,omitempty"`
-	EnforceEnvironment bool   `json:"enforce_environment,omitempty"`
+	EnforceEnvironment bool   `json:"enforce_environment"`
 	Debug              bool   `json:"debug,omitempty"`
 	Trace              bool   `json:"trace,omitempty"`
 	Evaltrace          bool   `json:"evaltrace,omitempty"`

--- a/pkg/orch/command_test.go
+++ b/pkg/orch/command_test.go
@@ -208,8 +208,9 @@ func TestCommandDeploy(t *testing.T) {
 	// Test success
 	setupPostResponder(t, orchCommandDeploy, "command-deploy-request.json", "command-deploy-response.json")
 	deployRequest := &DeployRequest{
-		Environment: "production",
-		Noop:        true,
+		Environment:        "production",
+		EnforceEnvironment: true,
+		Noop:               true,
 		Scope: Scope{
 			Nodes: []string{"node1.example.com"},
 		},

--- a/pkg/orch/testdata/apidocs/command-deploy-request.json
+++ b/pkg/orch/testdata/apidocs/command-deploy-request.json
@@ -1,7 +1,10 @@
 {
-  "environment" : "production",
-  "noop" : true,
-  "scope" : {
-    "nodes" : ["node1.example.com"]
+  "environment": "production",
+  "enforce_environment": true,
+  "noop": true,
+  "scope": {
+    "nodes": [
+      "node1.example.com"
+    ]
   }
 }


### PR DESCRIPTION
When attempting to set enforce environment to false on the DeployRequest struct, it will always be excluded from the marshaled json due to the omitempty tag used. It appears to be true by default on PE.

However removing this omitempty tag means that when using the DeployRequest you must make sure to set enforce environment to true to get default behaviour.