### PR TITLE
(CISC-1050) - add schedule_options for a task

### DIFF
--- a/pkg/orch/command.go
+++ b/pkg/orch/command.go
@@ -69,11 +69,12 @@ type ScheduledJobID struct {
 
 // ScheduleTaskRequest describes a scheduled task
 type ScheduleTaskRequest struct {
-	Environment   string            `json:"environment,omitempty"`
-	Task          string            `json:"task"`
-	Params        map[string]string `json:"params"`
-	Scope         Scope             `json:"scope"`
-	ScheduledTime string            `json:"scheduled_time"`
+	Environment     string            `json:"environment,omitempty"`
+	Task            string            `json:"task"`
+	Params          map[string]string `json:"params"`
+	Scope           Scope             `json:"scope"`
+	ScheduledTime   string            `json:"scheduled_time"`
+	ScheduleOptions *ScheduleOptions  `json:"schedule_options,omitempty"`
 }
 
 // CommandTaskTarget creates a new task-target (POST /command/task_target)

--- a/pkg/orch/command_test.go
+++ b/pkg/orch/command_test.go
@@ -101,6 +101,67 @@ func TestCommandScheduleTask(t *testing.T) {
 	testHTTPError(t, actual, err, http.StatusNotFound)
 }
 
+func TestCommandScheduleTaskWithScheduleOptions(t *testing.T) {
+
+	// Test success
+	setupPostResponder(t, orchCommandScheduleTask, "command-schedule_task-request.json", "command-schedule_task-response.json")
+	scheduleTaskRequest := &ScheduleTaskRequest{
+		Environment: "test-env-1",
+		Task:        "package",
+		Params: map[string]string{
+			"action":  "install",
+			"package": "httpd",
+		},
+		Scope: Scope{
+			Nodes: []string{"node1.example.com"},
+		},
+		ScheduledTime: "2027-05-05T19:50:08Z",
+		ScheduleOptions: &ScheduleOptions{
+			Interval: struct {
+				Units string "json:\"units\""
+				Value int    "json:\"value\""
+			}{
+				Units: "seconds",
+				Value: 86400,
+			},
+		},
+	}
+
+	actual, err := orchClient.CommandScheduleTask(scheduleTaskRequest)
+	require.Nil(t, err)
+	require.Equal(t, expectedCommandScheduleTaskResponse, actual)
+
+	// Test error
+	setupErrorResponder(t, orchCommandScheduleTask)
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+
+	// Test HTTP error
+	setupResponderWithStatusCodeAndBody(t, orchCommandScheduleTask, http.StatusBadRequest, []byte(`{"StatusCode": 400}`))
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	assert.Error(t, err)
+	require.Nil(t, actual)
+	testExpectError := getExpectedHTTPError(http.StatusBadRequest, "ignorefornow")
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Error("Error returned is not of type HTTP error.")
+	}
+	require.Equal(t, httpErr.StatusCode, testExpectError.StatusCode)
+
+	//Test Orchestrator error
+	setupErrorResponder(t, orchCommandScheduleTask)
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	require.Nil(t, actual)
+	assert.Error(t, err)
+	require.Equal(t, expectedError, err)
+
+	//Test HTTP error
+	setupResponderWithStatusCodeAndBody(t, orchCommandScheduleTask, http.StatusNotFound, []byte(`{"StatusCode": 400}`))
+	actual, err = orchClient.CommandScheduleTask(scheduleTaskRequest)
+	testHTTPError(t, actual, err, http.StatusNotFound)
+}
+
 var expectedCommandScheduleTaskResponse = &ScheduledJobID{ScheduledJob: struct {
 	ID   string "json:\"id\""
 	Name string "json:\"name\""

--- a/pkg/orch/testdata/apidocs/command-schedule_task-request.json
+++ b/pkg/orch/testdata/apidocs/command-schedule_task-request.json
@@ -8,5 +8,11 @@
   "scope" : {
     "nodes" : ["node1.example.com"]
   },
-  "scheduled_time" : "2027-05-05T19:50:08Z"
+  "scheduled_time" : "2027-05-05T19:50:08Z",
+  "schedule_options": {
+    "interval": {
+      "units": "seconds",
+      "value": 86400
+    }
+  }
 }

--- a/pkg/orch/types.go
+++ b/pkg/orch/types.go
@@ -20,3 +20,11 @@ type Pagination struct {
 	Offset int `json:"offset"`
 	Total  int `json:"total"`
 }
+
+// ScheduleOptions represents the schedule_options of a task
+type ScheduleOptions struct {
+	Interval struct {
+		Units string `json:"units"`
+		Value int    `json:"value"`
+	} `json:"interval"`
+}


### PR DESCRIPTION
This PR updates the go-pe-client to run tasks in intervals. 
Clients using the go-pe-client can now schedule a task to run at intervals by specifiying ScheduleOptions as part of the ScheduleTaskRequest of the orch package