### PR TITLE
(LIDAR-945) add new endpoint to return puppet db version

### DIFF
--- a/pkg/puppetdb/common_test.go
+++ b/pkg/puppetdb/common_test.go
@@ -3,6 +3,7 @@ package puppetdb
 import (
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -30,6 +31,23 @@ func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 	response.Body.Close()
 }
 
+func setupURLErrorResponder(t *testing.T, url string) {
+	setupURLResponderWithStatusCode(t, url, http.StatusNotFound)
+}
+
+func setupURLResponderWithStatusCode(t *testing.T, url string, statusCode int) {
+	setupResponderWithStatusCodeAndBody(t, url, statusCode, expectedURLError)
+}
+
+func setupResponderWithStatusCodeAndBody(t *testing.T, url string, statusCode int, response interface{}) {
+	httpmock.Reset()
+	responder, err := httpmock.NewJsonResponder(statusCode, response)
+	require.Nil(t, err)
+	httpmock.RegisterResponder(http.MethodGet, hostURL+url, responder)
+}
+
 var pdbClient *Client
 
 var hostURL = "https://test-host:8081"
+
+var expectedURLError = url.Error{Op: "nil", URL: hostURL, Err: nil}

--- a/pkg/puppetdb/status.go
+++ b/pkg/puppetdb/status.go
@@ -1,0 +1,18 @@
+package puppetdb
+
+const (
+	puppetDBStatus = "/status/v1/services/puppetdb-status"
+)
+
+// PDbStatus will return the status of the pdb server, specifically the service version.
+func (c *Client) PDbStatus() (*PDbStatus, error) {
+	payload := &PDbStatus{}
+	err := getRequest(c, puppetDBStatus, "", nil, nil, &payload)
+	return payload, err
+}
+
+// PDbStatus represents the puppet db status returned from the endpoint.
+// ServiceVersion (string): the service version of the pe server the endpoint calls out to
+type PDbStatus struct {
+	ServiceVersion string `json:"service_version,omitempty"`
+}

--- a/pkg/puppetdb/status_test.go
+++ b/pkg/puppetdb/status_test.go
@@ -1,20 +1,29 @@
 package puppetdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestStatus performs a test on the FactNames endpoint and verifies the expected response is returned.
+// TestStatus performs a test on the puppetdb-status endpoint and verifies the expected response is returned.
 func TestStatus(t *testing.T) {
-	// Test FactNames
+	// Test Status success
 	setupGetResponder(t, puppetDBStatus, "", "puppetdbstatus-response.json")
 	actual, err := pdbClient.PDbStatus()
 	require.Nil(t, err)
 	require.Equal(t, expectedStatuses, actual)
+
+	// Test error
+	setupURLErrorResponder(t, puppetDBStatus)
+	actual, err = pdbClient.PDbStatus()
+	require.Equal(t, expectedErrorStatuses, actual)
+	require.Equal(t, errExpectedURL, err)
 }
 
 var (
-	expectedStatuses = &PDbStatus{"6.8.1-20200122_170412-gc886602"}
+	expectedStatuses      = &PDbStatus{"6.8.1-20200122_170412-gc886602"}
+	expectedErrorStatuses = &PDbStatus{""}
+	errExpectedURL        = fmt.Errorf("https://test-host:8081 /status/v1/services/puppetdb-status: 404: \"{\"Op\":\"nil\",\"URL\":\"https://test-host:8081\",\"Err\":null}\"")
 )

--- a/pkg/puppetdb/status_test.go
+++ b/pkg/puppetdb/status_test.go
@@ -1,0 +1,20 @@
+package puppetdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatus performs a test on the FactNames endpoint and verifies the expected response is returned.
+func TestStatus(t *testing.T) {
+	// Test FactNames
+	setupGetResponder(t, puppetDBStatus, "", "puppetdbstatus-response.json")
+	actual, err := pdbClient.PDbStatus()
+	require.Nil(t, err)
+	require.Equal(t, expectedStatuses, actual)
+}
+
+var (
+	expectedStatuses = &PDbStatus{"6.8.1-20200122_170412-gc886602"}
+)

--- a/pkg/puppetdb/testdata/puppetdbstatus-response.json
+++ b/pkg/puppetdb/testdata/puppetdbstatus-response.json
@@ -1,0 +1,18 @@
+{
+  "service_version": "6.8.1-20200122_170412-gc886602",
+  "service_status_version": 1,
+  "detail_level": "info",
+  "state": "running",
+  "status": {
+    "maintenance_mode?": false,
+    "queue_depth": 0,
+    "read_db_up?": true,
+    "write_db_up?": true,
+    "rbac_status": "running",
+    "sync_status": {
+      "state": "idle"
+    }
+  },
+  "active_alerts": [],
+  "service_name": "puppetdb-status"
+}


### PR DESCRIPTION
to address backward compatibility issue with the Query service group_by clauses -
a new endpoint has been added to the go-pe-client to call to return the version of the puppet db