### PR TITLE
fix: change params from string to interface{}

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -164,7 +164,7 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 
 	jobID, err := orchClient.CommandTask(&orch.TaskRequest{
 		Task: "package",
-		Params: map[string]string{
+		Params: map[string]interface{}{
 			"action": "status",
 			"name":   "openssl",
 		},
@@ -189,7 +189,7 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 
 	scheduledJobID, err := orchClient.CommandScheduleTask(&orch.ScheduleTaskRequest{
 		Task: "package",
-		Params: map[string]string{
+		Params: map[string]interface{}{
 			"action": "status",
 			"name":   "openssl",
 		},

--- a/pkg/orch/command.go
+++ b/pkg/orch/command.go
@@ -39,10 +39,10 @@ type JobID struct {
 
 // TaskRequest describes a task to be run
 type TaskRequest struct {
-	Environment string            `json:"environment,omitempty"`
-	Task        string            `json:"task"`
-	Params      map[string]string `json:"params"`
-	Scope       Scope             `json:"scope"`
+	Environment string                 `json:"environment,omitempty"`
+	Task        string                 `json:"task"`
+	Params      map[string]interface{} `json:"params"`
+	Scope       Scope                  `json:"scope"`
 }
 
 // CommandScheduleTask schedules a task to run at a future date and time (POST /command/schedule_task)
@@ -77,12 +77,12 @@ type ScheduledJobID struct {
 
 // ScheduleTaskRequest describes a scheduled task
 type ScheduleTaskRequest struct {
-	Environment     string            `json:"environment,omitempty"`
-	Task            string            `json:"task"`
-	Params          map[string]string `json:"params"`
-	Scope           Scope             `json:"scope"`
-	ScheduledTime   string            `json:"scheduled_time"`
-	ScheduleOptions *ScheduleOptions  `json:"schedule_options,omitempty"`
+	Environment     string                 `json:"environment,omitempty"`
+	Task            string                 `json:"task"`
+	Params          map[string]interface{} `json:"params"`
+	Scope           Scope                  `json:"scope"`
+	ScheduledTime   string                 `json:"scheduled_time"`
+	ScheduleOptions *ScheduleOptions       `json:"schedule_options,omitempty"`
 }
 
 // CommandTaskTarget creates a new task-target (POST /command/task_target)

--- a/pkg/orch/command_test.go
+++ b/pkg/orch/command_test.go
@@ -16,7 +16,7 @@ func TestCommandTask(t *testing.T) {
 	taskRequest := &TaskRequest{
 		Environment: "test-env-1",
 		Task:        "package",
-		Params: map[string]string{
+		Params: map[string]interface{}{
 			"action": "install",
 			"name":   "httpd",
 		},
@@ -57,7 +57,7 @@ func TestCommandScheduleTask(t *testing.T) {
 	scheduleTaskRequest := &ScheduleTaskRequest{
 		Environment: "test-env-1",
 		Task:        "package",
-		Params: map[string]string{
+		Params: map[string]interface{}{
 			"action":  "install",
 			"package": "httpd",
 		},
@@ -111,7 +111,7 @@ func TestCommandScheduleTaskWithScheduleOptions(t *testing.T) {
 	scheduleTaskRequest := &ScheduleTaskRequest{
 		Environment: "test-env-1",
 		Task:        "package",
-		Params: map[string]string{
+		Params: map[string]interface{}{
 			"action":  "install",
 			"package": "httpd",
 		},


### PR DESCRIPTION
# BREAKING CHANGE!

This will break existing code that uses the following:

* `orch.CommandTask`
* `orch.CommandScheduleTask`

... due to a change in the Params type in `TaskRequest` and `ScheduleTaskRequest` respectively.

As this breaks backwards compatibility, this may have to be a major release.

Fixes #59 