### PR TITLE
(CISC-1327) Error message is incorrectly formatted

### DIFF
--- a/pkg/classifier/client.go
+++ b/pkg/classifier/client.go
@@ -51,16 +51,16 @@ func getRequest(client *Client, path string, pagination *Pagination, response in
 	if err != nil {
 		var ue *url.Error
 		if errors.As(err, &ue) {
-			return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, ue.Err)
+			return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, ue.Err)
 		}
-		return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, err)
+		return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, err)
 	}
 	if r.IsError() {
 		re := r.Error()
 		if re == nil {
-			return fmt.Errorf("%s %s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
+			return fmt.Errorf("%s%s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
 		}
-		return fmt.Errorf("%s %s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
+		return fmt.Errorf("%s%s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
 	}
 
 	return nil
@@ -76,16 +76,16 @@ func postRequest(client *Client, path string, body string, response interface{})
 	if err != nil {
 		var ue *url.Error
 		if errors.As(err, &ue) {
-			return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, ue.Err)
+			return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, ue.Err)
 		}
-		return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, err)
+		return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, err)
 	}
 	if r.IsError() {
 		re := r.Error()
 		if re == nil {
-			return fmt.Errorf("%s %s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
+			return fmt.Errorf("%s%s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
 		}
-		return fmt.Errorf("%s %s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
+		return fmt.Errorf("%s%s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
 	}
 
 	return nil

--- a/pkg/puppetdb/client.go
+++ b/pkg/puppetdb/client.go
@@ -64,16 +64,16 @@ func getRequest(client *Client, path string, query string, pagination *Paginatio
 	if err != nil {
 		var ue *url.Error
 		if errors.As(err, &ue) {
-			return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, ue.Err)
+			return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, ue.Err)
 		}
-		return fmt.Errorf("%s %s: %w", client.resty.HostURL, path, err)
+		return fmt.Errorf("%s%s: %w", client.resty.HostURL, path, err)
 	}
 	if r.IsError() {
 		re := r.Error()
 		if re == nil {
-			return fmt.Errorf("%s %s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
+			return fmt.Errorf("%s%s: %s: \"%s\"", client.resty.HostURL, path, r.Status(), r.Body())
 		}
-		return fmt.Errorf("%s %s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
+		return fmt.Errorf("%s%s: %s: \"%s\": %v", client.resty.HostURL, path, r.Status(), r.Body(), re)
 	}
 
 	if pagination != nil && pagination.IncludeTotal {

--- a/pkg/puppetdb/status_test.go
+++ b/pkg/puppetdb/status_test.go
@@ -25,5 +25,5 @@ func TestStatus(t *testing.T) {
 var (
 	expectedStatuses      = &PDbStatus{"6.8.1-20200122_170412-gc886602"}
 	expectedErrorStatuses = &PDbStatus{""}
-	errExpectedURL        = fmt.Errorf("https://test-host:8081 /status/v1/services/puppetdb-status: 404: \"{\"Op\":\"nil\",\"URL\":\"https://test-host:8081\",\"Err\":null}\"")
+	errExpectedURL        = fmt.Errorf("https://test-host:8081/status/v1/services/puppetdb-status: 404: \"{\"Op\":\"nil\",\"URL\":\"https://test-host:8081\",\"Err\":null}\"")
 )


### PR DESCRIPTION
Changing it from this
```
time="2021-06-24T18:23:15Z" level=error msg="{{Unable to retrieve nodes from PE https://puppet.fissa.alight-fed.com:8081 /pdb/query/v4/facts: 403 Forbidden: \"Permission denied: User does not have permission to access PuppetDB\"}}"
```

to

```
time="2021-06-24T18:23:15Z" level=error msg="{{Unable to retrieve nodes from PE https://puppet.fissa.alight-fed.com:8081/pdb/query/v4/facts: 403 Forbidden: \"Permission denied: User does not have permission to access PuppetDB\"}}"

```