### PR TITLE
Add support for RBAC API get roles endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 language: go
 
 go:
-  - 1.14.x
+  - 1.19.x
 
 script:
   - make

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -61,10 +61,10 @@ func handlerClassifierGroups(peServer string, token string) {
 func main() {
 	if len(os.Args) < 3 {
 		msg := `Runs through a gamut of PDB and Orchestration queries or returns an RBAC token
-Run the queries: go run cmd/main.go <pe-server> <token> e.g. go run cmd/main.go pe.puppetlabs.net aabbccddeeff
+Run the queries: go run cmd/test/main.go <pe-server> <token> e.g. go run cmd/test/main.go pe.puppetlabs.net aabbccddeeff
 or
-Run a classifier query: go run cmd/main.go classifier [nodes/groups] <pe-server> [nodename] <token>
-Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go run cmd/main.go pe.puppetlabs.net admin pazzw0rd`
+Run a classifier query: go run cmd/test/main.go classifier [nodes/groups] <pe-server> [nodename] <token>
+Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. go run cmd/test/main.go pe.puppetlabs.net admin pazzw0rd`
 		panic(msg)
 	}
 
@@ -133,7 +133,7 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 	rbacHostURL := "https://" + peServer + ":4433"
 	rbacClient := rbac.NewClient(rbacHostURL, &tls.Config{InsecureSkipVerify: true}) // #nosec - this main() is private and for development purpose
 
-	fmt.Println("Connecting to:", peServer)
+	fmt.Printf("Connecting to: %s\n\n", peServer)
 
 	// Try creating the same role (same display name) multiple times,
 	// the second attempt should return a HTTP 409 status.
@@ -150,7 +150,6 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 				},
 			},
 		}, token)
-
 		if err != nil {
 			if apiErr, ok := err.(*rbac.APIError); ok {
 				if apiErr.GetStatusCode() == 409 {
@@ -171,6 +170,27 @@ Get the RBAC token: go run cmd/main.go <pe-server> <login> <password> e.g. go ru
 			location)
 	}
 	fmt.Println()
+
+	var roles []rbac.Role
+	roles, err := rbacClient.GetRoles(token)
+	if err != nil {
+		panic(err)
+	}
+
+	var createdRolePresent bool
+	for _, role := range roles {
+		if role.DisplayName == roleDisplayName {
+			createdRolePresent = true
+			break
+		}
+	}
+
+	if createdRolePresent {
+		fmt.Printf("Get roles was successful, as role \"%s\" was present in response\n\n", roleDisplayName)
+	} else {
+		panic(fmt.Sprintf("Expected the role \"%s\" to be present in the response from get roles, but it was not",
+			roleDisplayName))
+	}
 
 	environments, err := peClient.Environments()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/puppetlabs/go-pe-client
 
-go 1.14
+go 1.19
 
 require (
 	github.com/c-bata/go-prompt v0.2.3

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,19 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-resty/resty/v2 v2.2.0
 	github.com/jarcoal/httpmock v1.0.4
+	github.com/sirupsen/logrus v1.5.0
+	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
-	github.com/sirupsen/logrus v1.5.0
-	github.com/stretchr/testify v1.7.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
+	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,13 +45,9 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/pkg/classifier/groups_test.go
+++ b/pkg/classifier/groups_test.go
@@ -2,8 +2,8 @@ package classifier
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -35,7 +35,7 @@ func TestGroup(t *testing.T) {
 
 func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 	httpmock.Reset()
-	responseBody, err := ioutil.ReadFile("testdata/" + responseFilename)
+	responseBody, err := os.ReadFile("testdata/" + responseFilename)
 	require.Nil(t, err)
 	response := httpmock.NewBytesResponse(200, responseBody)
 	response.Header.Set("Content-Type", "application/json")
@@ -84,6 +84,7 @@ var (
 		Deleted:           map[string]interface{}(nil),
 	}
 )
+
 var expected = []Group{
 	g, g2,
 }

--- a/pkg/orch/common_test.go
+++ b/pkg/orch/common_test.go
@@ -2,7 +2,6 @@ package orch
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -21,7 +20,7 @@ func init() {
 
 func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 	httpmock.Reset()
-	responseBody, err := ioutil.ReadFile("testdata/apidocs/" + responseFilename)
+	responseBody, err := os.ReadFile("testdata/apidocs/" + responseFilename)
 	require.Nil(t, err)
 	response := httpmock.NewBytesResponse(200, responseBody)
 	response.Header.Set("Content-Type", "application/json")
@@ -49,7 +48,7 @@ func setupPostResponder(t *testing.T, url, requestFilename, responseFilename str
 			require.Equal(t, expected, actual)
 
 			// Build response
-			responseBody, err := ioutil.ReadFile("testdata/apidocs/" + responseFilename)
+			responseBody, err := os.ReadFile("testdata/apidocs/" + responseFilename)
 			require.Nil(t, err)
 			response := httpmock.NewBytesResponse(200, responseBody)
 			response.Header.Set("Content-Type", "application/json")

--- a/pkg/pe/common_test.go
+++ b/pkg/pe/common_test.go
@@ -1,8 +1,8 @@
 package pe
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -18,7 +18,7 @@ func init() {
 
 func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 	httpmock.Reset()
-	responseBody, err := ioutil.ReadFile("testdata/apidocs/" + responseFilename)
+	responseBody, err := os.ReadFile("testdata/apidocs/" + responseFilename)
 	require.Nil(t, err)
 	response := httpmock.NewBytesResponse(200, responseBody)
 	response.Header.Set("Content-Type", "application/json")

--- a/pkg/puppetdb/common_test.go
+++ b/pkg/puppetdb/common_test.go
@@ -1,9 +1,9 @@
 package puppetdb
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -19,7 +19,7 @@ func init() {
 
 func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 	httpmock.Reset()
-	responseBody, err := ioutil.ReadFile("testdata/" + responseFilename)
+	responseBody, err := os.ReadFile("testdata/" + responseFilename)
 	require.Nil(t, err)
 	response := httpmock.NewBytesResponse(200, responseBody)
 	response.Header.Set("Content-Type", "application/json")

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -12,15 +12,36 @@ import (
 )
 
 func init() {
-	rbacClient = NewClient(rbacHostURL, nil)
+	rbacClient = NewClient(rbacAPIOrigin, nil)
 	rbacClient.strict = true
 	httpmock.Activate()
 	httpmock.ActivateNonDefault(rbacClient.resty.GetClient())
 }
 
+func setUpOKResponder(t *testing.T, httpMethod string, path string, responseFilePath string) {
+	httpmock.Reset()
+
+	responseBody, err := os.ReadFile(responseFilePath)
+	require.Nil(t, err)
+
+	response := httpmock.NewBytesResponse(http.StatusOK, responseBody)
+	response.Header.Set("Content-Type", "application/json")
+
+	httpmock.RegisterResponder(httpMethod, rbacAPIOrigin+path, httpmock.ResponderFromResponse(response))
+}
+
+func setUpBadRequestResponder(t *testing.T, httpMethod string, path string) {
+	httpmock.Reset()
+
+	responder, err := httpmock.NewJsonResponder(http.StatusBadRequest, expectedError)
+	require.Nil(t, err)
+
+	httpmock.RegisterResponder(httpMethod, rbacAPIOrigin+path, responder)
+}
+
 func setupPostResponder(t *testing.T, url, requestFilename, responseFilename string) {
 	httpmock.Reset()
-	httpmock.RegisterResponder(http.MethodPost, rbacHostURL+url,
+	httpmock.RegisterResponder(http.MethodPost, rbacAPIOrigin+url,
 		func(req *http.Request) (*http.Response, error) {
 			// Validate the body
 			actual := map[string]interface{}{}
@@ -43,17 +64,9 @@ func setupPostResponder(t *testing.T, url, requestFilename, responseFilename str
 	)
 }
 
-func setupErrorResponder(t *testing.T, url string) {
-	httpmock.Reset()
-	responder, err := httpmock.NewJsonResponder(400, expectedError)
-	require.Nil(t, err)
-	httpmock.RegisterResponder(http.MethodGet, rbacHostURL+url, responder)
-	httpmock.RegisterResponder(http.MethodPost, rbacHostURL+url, responder)
-}
-
 func setupCreateRoleSuccessResponder(t *testing.T, url string, requestFilename string) {
 	httpmock.Reset()
-	httpmock.RegisterResponder(http.MethodPost, rbacHostURL+url,
+	httpmock.RegisterResponder(http.MethodPost, rbacAPIOrigin+url,
 		func(req *http.Request) (*http.Response, error) {
 			// Validate the body
 			actual := map[string]interface{}{}
@@ -79,13 +92,13 @@ func setupCreateRoleErrorResponder(t *testing.T, url string) {
 	httpmock.Reset()
 	responder, err := httpmock.NewJsonResponder(409, createRoleDuplicateError)
 	require.Nil(t, err)
-	httpmock.RegisterResponder(http.MethodGet, rbacHostURL+url, responder)
-	httpmock.RegisterResponder(http.MethodPost, rbacHostURL+url, responder)
+	httpmock.RegisterResponder(http.MethodGet, rbacAPIOrigin+url, responder)
+	httpmock.RegisterResponder(http.MethodPost, rbacAPIOrigin+url, responder)
 }
 
 var rbacClient *Client
 
-var rbacHostURL = "https://test-host:4433"
+var rbacAPIOrigin = "https://test-host:4433"
 
 var expectedError = &APIError{
 	Kind:       "puppetlabs.rbac/unknown-environment",

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -2,7 +2,6 @@ package rbac
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -28,6 +27,7 @@ func setUpOKResponder(t *testing.T, httpMethod string, path string, responseFile
 	response.Header.Set("Content-Type", "application/json")
 
 	httpmock.RegisterResponder(httpMethod, rbacAPIOrigin+path, httpmock.ResponderFromResponse(response))
+	response.Body.Close()
 }
 
 func setUpBadRequestResponder(t *testing.T, httpMethod string, path string) {
@@ -55,7 +55,7 @@ func setupPostResponder(t *testing.T, url, requestFilename, responseFilename str
 			require.Equal(t, expected, actual)
 
 			// Build response
-			responseBody, err := ioutil.ReadFile("testdata/apidocs/" + responseFilename)
+			responseBody, err := os.ReadFile("testdata/apidocs/" + responseFilename)
 			require.Nil(t, err)
 			response := httpmock.NewBytesResponse(200, responseBody)
 			response.Header.Set("Content-Type", "application/json")

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -1,7 +1,7 @@
 package rbac
 
 const (
-	rbacRoles = "/rbac-api/v1/roles"
+	rolesPath = "/rbac-api/v1/roles"
 )
 
 // CreateRole creates a role, and attaches to it the specified permissions and
@@ -9,11 +9,11 @@ const (
 //
 // If the role was created successfully then the path of the new role is
 // returned, otherwise an error is returned.
-func (c *Client) CreateRole(roles *Role, token string) (string, error) {
+func (c *Client) CreateRole(role *Role, token string) (string, error) {
 	r, err := c.resty.R().
-		SetBody(roles).
+		SetBody(role).
 		SetHeader("X-Authentication", token).
-		Post(rbacRoles)
+		Post(rolesPath)
 	if err != nil {
 		// This API uses a redirect with location header to indicate success.
 		// Because redirects are disabled in the RBAC client an

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -40,7 +40,7 @@ type Role struct {
 	UserIDs     []string     `json:"user_ids"`
 	GroupIDs    []string     `json:"group_ids"`
 	DisplayName string       `json:"display_name"`
-	Description string       `json:"description,omitempty"`
+	Description string       `json:"description"`
 }
 
 // Permission represents an RBAC permission

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -4,6 +4,21 @@ const (
 	rolesPath = "/rbac-api/v1/roles"
 )
 
+// GetRoles fetches information about all user roles.
+func (c *Client) GetRoles(token string) ([]Role, error) {
+	var roles []Role
+
+	response, err := c.resty.R().
+		SetHeader("X-Authentication", token).
+		SetResult(&roles).
+		Get(rolesPath)
+	if err != nil {
+		return nil, FormatError(response, err.Error())
+	}
+
+	return roles, nil
+}
+
 // CreateRole creates a role, and attaches to it the specified permissions and
 // the specified users and groups. Authentication is required.
 //

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -36,6 +36,7 @@ func (c *Client) CreateRole(roles *Role, token string) (string, error) {
 
 // Role represents an RBAC role
 type Role struct {
+	ID          uint         `json:"id,omitempty"`
 	Permissions []Permission `json:"permissions"`
 	UserIDs     []string     `json:"user_ids"`
 	GroupIDs    []string     `json:"group_ids"`

--- a/pkg/rbac/roles_test.go
+++ b/pkg/rbac/roles_test.go
@@ -10,20 +10,20 @@ import (
 )
 
 const (
-	responseFilePath = "testdata/apidocs/GetRoles-response.json"
-	token            = "dummy-token"
+	getRolesResponseFilePath = "testdata/apidocs/GetRoles-response.json"
+	token                    = "dummy-token"
 )
 
 func TestGetRoles(t *testing.T) {
 	var expectedRoles []Role
 
-	expectedRolesJSONFile, err := os.Open(responseFilePath)
+	expectedRolesJSONFile, err := os.Open(getRolesResponseFilePath)
 	require.Nil(t, err, "failed to open expected roles JSON file")
 
 	err = json.NewDecoder(expectedRolesJSONFile).Decode(&expectedRoles)
 	require.Nil(t, err, "error decoding expected roles")
 
-	setUpOKResponder(t, http.MethodGet, rolesPath, responseFilePath)
+	setUpOKResponder(t, http.MethodGet, rolesPath, getRolesResponseFilePath)
 
 	actualRoles, err := rbacClient.GetRoles(token)
 	require.Nil(t, err)

--- a/pkg/rbac/roles_test.go
+++ b/pkg/rbac/roles_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestCreateRole(t *testing.T) {
-
 	var (
 		token = "dummyToken"
 
@@ -25,13 +24,13 @@ func TestCreateRole(t *testing.T) {
 	)
 
 	// Test success
-	setupCreateRoleSuccessResponder(t, rbacRoles, "CreateRole-request.json")
+	setupCreateRoleSuccessResponder(t, rolesPath, "CreateRole-request.json")
 	actual, err := rbacClient.CreateRole(role, token)
 	require.Nil(t, err)
 	require.Equal(t, "/path/to/role", actual)
 
 	// Test error
-	setupCreateRoleErrorResponder(t, rbacRoles)
+	setupCreateRoleErrorResponder(t, rolesPath)
 	location, err := rbacClient.CreateRole(role, token)
 	require.NotNil(t, err)
 	require.Equal(t, "", location)

--- a/pkg/rbac/testdata/apidocs/GetRoles-response.json
+++ b/pkg/rbac/testdata/apidocs/GetRoles-response.json
@@ -1,0 +1,19 @@
+[
+  {
+    "description": "Role used in go-pe-client get roles test",
+    "display_name": "Test Role",
+    "id": 1,
+    "group_ids": [],
+    "user_ids": [
+      "af94921f-bd76-4b58-b5ce-e17c029a2790",
+      "42bf351c-f9ec-40af-84ad-e976fec7f4bd"
+    ],
+    "permissions": [
+      {
+        "object_type": "node_groups",
+        "action": "view",
+        "instance": "*"
+      }
+    ]
+  }
+]

--- a/pkg/rbac/token_test.go
+++ b/pkg/rbac/token_test.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ func TestGetRBACToken(t *testing.T) {
 	require.Equal(t, expectedResponse, actual)
 
 	// Test error
-	setupErrorResponder(t, requestAuthTokenURI)
+	setUpBadRequestResponder(t, http.MethodPost, requestAuthTokenURI)
 	actual, err = rbacClient.GetRBACToken(request)
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)


### PR DESCRIPTION
**Resolves ticket:** [CISC-3188](https://tickets.puppetlabs.com/browse/CISC-3188)

**Summary of changes:**
* Added support for the PE RBAC API endpoint `GET /roles`
* Added an accompanying unit test and integration test
* Performed some minor opportunistic refactoring
* Bumped the Go version from 1.14 to 1.19

**Integration test output:**
```
% go run cmd/test/main.go oblique-heel.delivery.puppetlabs.net AKKwQ3aLRTgDWm_ysp8FVdXFMAyNDUTRFQT9kX1cqf9_
Connecting to: oblique-heel.delivery.puppetlabs.net

Create role "Testing 1680269553911422000" was successful, location: /rbac-api/v1/roles/6
Create role "Testing 1680269553911422000" failed as expected because role already exists

Get roles was successful, as role "Testing 1680269553911422000" was present in response
```