### PR TITLE
Add support for RBAC API get role endpoint

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -135,6 +137,10 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 
 	fmt.Printf("Connecting to: %s\n\n", peServer)
 
+	fmt.Printf("* Testing RBAC API client function CreateRole...\n\n")
+
+	var createdRoleID string
+
 	// Try creating the same role (same display name) multiple times,
 	// the second attempt should return a HTTP 409 status.
 	roleDisplayName := fmt.Sprintf("Testing %d", time.Now().UnixNano())
@@ -152,7 +158,7 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 		}, token)
 		if err != nil {
 			if apiErr, ok := err.(*rbac.APIError); ok {
-				if apiErr.GetStatusCode() == 409 {
+				if apiErr.GetStatusCode() == http.StatusConflict {
 					fmt.Printf("Create role \"%s\" failed as expected because role already exists\n",
 						roleDisplayName)
 				} else {
@@ -165,14 +171,34 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 			}
 			panic(err)
 		}
+		createdRoleID = location[strings.LastIndex(location, "/")+1:]
+
 		fmt.Printf("Create role \"%s\" was successful, location: %s\n",
 			roleDisplayName,
 			location)
 	}
 	fmt.Println()
 
+	fmt.Printf("* Testing RBAC API client function GetRole...\n\n")
+
+	var role *rbac.Role
+	role, err := rbacClient.GetRole(createdRoleID, token)
+	if err != nil {
+		panic(err)
+	}
+
+	if role.DisplayName == roleDisplayName {
+		fmt.Printf("Get role was successful, as the role \"%s\" was returned in response\n\n",
+			roleDisplayName)
+	} else {
+		panic(fmt.Sprintf("Expected the role \"%s\" to be returned in response from get role, but it was not",
+			roleDisplayName))
+	}
+
+	fmt.Printf("* Testing RBAC API client function GetRoles...\n\n")
+
 	var roles []rbac.Role
-	roles, err := rbacClient.GetRoles(token)
+	roles, err = rbacClient.GetRoles(token)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -139,7 +140,7 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 
 	fmt.Printf("* Testing RBAC API client function CreateRole...\n\n")
 
-	var createdRoleID string
+	var createdRoleIDString string
 
 	// Try creating the same role (same display name) multiple times,
 	// the second attempt should return a HTTP 409 status.
@@ -171,7 +172,7 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 			}
 			panic(err)
 		}
-		createdRoleID = location[strings.LastIndex(location, "/")+1:]
+		createdRoleIDString = location[strings.LastIndex(location, "/")+1:]
 
 		fmt.Printf("Create role \"%s\" was successful, location: %s\n",
 			roleDisplayName,
@@ -182,7 +183,9 @@ Get the RBAC token: go run cmd/test/main.go <pe-server> <login> <password> e.g. 
 	fmt.Printf("* Testing RBAC API client function GetRole...\n\n")
 
 	var role *rbac.Role
-	role, err := rbacClient.GetRole(createdRoleID, token)
+
+	createdRoleID, _ := strconv.Atoi(createdRoleIDString)
+	role, err := rbacClient.GetRole(uint(createdRoleID), token)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -1,6 +1,7 @@
 package rbac
 
 const (
+	rolePath  = "/rbac-api/v1/roles/{id}"
 	rolesPath = "/rbac-api/v1/roles"
 )
 
@@ -17,6 +18,22 @@ func (c *Client) GetRoles(token string) ([]Role, error) {
 	}
 
 	return roles, nil
+}
+
+// GetRole fetches information about a single role, identified by its ID.
+func (c *Client) GetRole(id string, token string) (*Role, error) {
+	var role Role
+
+	response, err := c.resty.R().
+		SetHeader("X-Authentication", token).
+		SetPathParams(map[string]string{"id": id}).
+		SetResult(&role).
+		Get(rolePath)
+	if err != nil {
+		return nil, FormatError(response, err.Error())
+	}
+
+	return &role, nil
 }
 
 // CreateRole creates a role, and attaches to it the specified permissions and

--- a/pkg/rbac/roles.go
+++ b/pkg/rbac/roles.go
@@ -1,5 +1,7 @@
 package rbac
 
+import "strconv"
+
 const (
 	rolePath  = "/rbac-api/v1/roles/{id}"
 	rolesPath = "/rbac-api/v1/roles"
@@ -21,12 +23,12 @@ func (c *Client) GetRoles(token string) ([]Role, error) {
 }
 
 // GetRole fetches information about a single role, identified by its ID.
-func (c *Client) GetRole(id string, token string) (*Role, error) {
+func (c *Client) GetRole(id uint, token string) (*Role, error) {
 	var role Role
 
 	response, err := c.resty.R().
 		SetHeader("X-Authentication", token).
-		SetPathParams(map[string]string{"id": id}).
+		SetPathParams(map[string]string{"id": strconv.FormatUint(uint64(id), 10)}).
 		SetResult(&role).
 		Get(rolePath)
 	if err != nil {

--- a/pkg/rbac/roles_test.go
+++ b/pkg/rbac/roles_test.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 const (
+	getRoleResponseFilePath  = "testdata/apidocs/GetRole-response.json"
 	getRolesResponseFilePath = "testdata/apidocs/GetRoles-response.json"
 	token                    = "dummy-token"
 )
@@ -28,6 +31,23 @@ func TestGetRoles(t *testing.T) {
 	actualRoles, err := rbacClient.GetRoles(token)
 	require.Nil(t, err)
 	require.Equal(t, expectedRoles, actualRoles)
+}
+
+func TestGetRole(t *testing.T) {
+	var expectedRole *Role
+
+	expectedRoleJSONFile, err := os.Open(getRoleResponseFilePath)
+	require.Nil(t, err, "failed to open expected role JSON file")
+
+	err = json.NewDecoder(expectedRoleJSONFile).Decode(&expectedRole)
+	require.Nil(t, err, "error decoding expected role")
+
+	rolePathWithID := strings.ReplaceAll(rolePath, "{id}", strconv.Itoa(int(expectedRole.ID)))
+	setUpOKResponder(t, http.MethodGet, rolePathWithID, getRoleResponseFilePath)
+
+	actualRole, err := rbacClient.GetRole(expectedRole.ID, token)
+	require.Nil(t, err)
+	require.Equal(t, expectedRole, actualRole)
 }
 
 func TestCreateRole(t *testing.T) {

--- a/pkg/rbac/testdata/apidocs/GetRole-response.json
+++ b/pkg/rbac/testdata/apidocs/GetRole-response.json
@@ -1,0 +1,17 @@
+{
+  "description": "Role used in go-pe-client get role test",
+  "display_name": "Test Role",
+  "id": 1,
+  "group_ids": [],
+  "user_ids": [
+    "af94921f-bd76-4b58-b5ce-e17c029a2790",
+    "42bf351c-f9ec-40af-84ad-e976fec7f4bd"
+  ],
+  "permissions": [
+    {
+      "object_type": "node_groups",
+      "action": "view",
+      "instance": "*"
+    }
+  ]
+}


### PR DESCRIPTION
**Resolves ticket:** [CISC-3191](https://tickets.puppetlabs.com/browse/CISC-3191)

**Summary of changes:**
* Added support for the PE RBAC API endpoint `GET /role/:id`
* Added an accompanying unit test and integration test

**Integration test output:**
```
% go run cmd/test/main.go epicyclical-pro.delivery.puppetlabs.net AL40f61YgFIhtIT_n1XBeWTbclTilG2r8NTSFX7ndHxP
Connecting to: epicyclical-pro.delivery.puppetlabs.net

* Testing RBAC API client function CreateRole...

Create role "Testing 1680519311359000000" was successful, location: /rbac-api/v1/roles/12
Create role "Testing 1680519311359000000" failed as expected because role already exists

* Testing RBAC API client function GetRole...

Get role was successful, as the role "Testing 1680519311359000000" was returned in response

* Testing RBAC API client function GetRoles...

Get roles was successful, as role "Testing 1680519311359000000" was present in response
```