### PR TITLE
pdb client: generalizes the pagination cursor

### DIFF
--- a/pkg/puppetdb/nodes.go
+++ b/pkg/puppetdb/nodes.go
@@ -1,9 +1,9 @@
 package puppetdb
 
 import (
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 )
 
@@ -24,32 +24,16 @@ func (c *Client) Nodes(query string, pagination *Pagination, orderBy *OrderBy) (
 // information for tracking progress. If pagination is nil, then a default
 // configuration with a limit of 100 is used instead.
 func (c *Client) PaginatedNodes(query string, pagination *Pagination, orderBy *OrderBy) (*NodesCursor, error) {
-	if pagination == nil {
-		pagination = &Pagination{Limit: 100}
+	pc, err := newPageCursor(c, nodes, query, pagination, orderBy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize page cursor: %w", err)
 	}
 
-	tempPagination := Pagination{
-		Limit:        1,
-		IncludeTotal: true,
+	cursor := NodesCursor{
+		pageCursor: pc,
 	}
 
-	// make a call to pdb for 1 node to fetch the total number of nodes for
-	// page calculations in the cursor.
-	if _, err := c.Nodes(query, &tempPagination, orderBy); err != nil {
-		return nil, fmt.Errorf("failed to get node total from pdb: %w", err)
-	}
-
-	pagination.Total = tempPagination.Total
-	pagination.IncludeTotal = true
-
-	nc := &NodesCursor{
-		client:     c,
-		pagination: pagination,
-		query:      query,
-		orderBy:    orderBy,
-	}
-
-	return nc, nil
+	return &cursor, nil
 }
 
 // Node will return a single node by certname
@@ -95,53 +79,17 @@ type Node struct {
 // NodesCursor is a pagination cursor that provides convenience methods for
 // stepping through pages of nodes.
 type NodesCursor struct {
-	client      *Client
-	pagination  *Pagination
-	query       string
-	orderBy     *OrderBy
-	currentPage []Node
+	*pageCursor
 }
 
 // Next returns a page of nodes and iterates the pagination cursor by the
 // offset. If there are no more results left, the error will be io.EOF.
 func (nc *NodesCursor) Next() ([]Node, error) {
-	// this block increases the offset and checks of it's greater than or equal
-	// to the total only if we have already returned a first page.
-	if nc.currentPage != nil {
-		nc.pagination.Offset = nc.pagination.Offset + nc.pagination.Limit
-
-		if nc.pagination.Offset >= nc.pagination.Total {
-			return []Node{}, io.EOF
-		}
+	payload := []Node{}
+	err := nc.next(&payload)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
 	}
 
-	var err error
-
-	nc.currentPage, err = nc.client.Nodes(nc.query, nc.pagination, nc.orderBy)
-	if err != nil {
-		return nil, fmt.Errorf("client call for Nodes returned an error: %w", err)
-	}
-
-	if nc.CurrentPage() == nc.TotalPages() {
-		err = io.EOF
-	}
-
-	return nc.currentPage, err
-}
-
-// TotalPages returns the total number of pages that can returns nodes.
-func (nc *NodesCursor) TotalPages() int {
-	pagesf := float64(nc.pagination.Total) / float64(nc.pagination.Limit)
-	pages := int(math.Ceil(pagesf))
-
-	return pages
-}
-
-// CurrentPage returns the current page number the cursor is at.
-func (nc *NodesCursor) CurrentPage() int {
-	if nc.pagination.Offset == 0 {
-		return 1
-	}
-
-	return nc.pagination.Offset/nc.pagination.Limit + 1
+	return payload, err
 }

--- a/pkg/puppetdb/pagination.go
+++ b/pkg/puppetdb/pagination.go
@@ -1,6 +1,11 @@
 package puppetdb
 
-import "strconv"
+import (
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+)
 
 // toParams will take the Pagination struct and convert into a form Client SetQueryParam accepts
 func (p Pagination) toParams() map[string]string {
@@ -24,4 +29,104 @@ type Pagination struct {
 	Offset       int
 	IncludeTotal bool
 	Total        int
+}
+
+func NewDefaultPagination() *Pagination {
+	return &Pagination{
+		Limit:        100,
+		IncludeTotal: true,
+	}
+}
+
+// pageCursor is a pagination cursor that provides convenience methods for
+// stepping through pbd response pages.
+type pageCursor struct {
+	client      *Client
+	path        string
+	query       string
+	pagination  *Pagination
+	orderBy     *OrderBy
+	currentPage any
+}
+
+// Next returns a page of nodes and iterates the pagination cursor by the
+// offset. If there are no more results left, the error will be io.EOF.
+func (pc *pageCursor) next(response any) error {
+	// this block increases the offset and checks of it's greater than or equal
+	// to the total only if we have already returned a first page.
+	if pc.currentPage != nil {
+		pc.pagination.Offset = pc.pagination.Offset + pc.pagination.Limit
+
+		if pc.pagination.Offset >= pc.pagination.Total {
+			return io.EOF
+		}
+	} else {
+		if pc.pagination == nil {
+			pc.pagination = NewDefaultPagination()
+		}
+
+		pc.pagination.IncludeTotal = true
+	}
+
+	var err error
+
+	err = getRequest(pc.client, pc.path, pc.query, pc.pagination, pc.orderBy, response)
+	if err != nil {
+		return fmt.Errorf("page cursor: client call returned an error: %w", err)
+	}
+
+	pc.currentPage = response
+
+	if pc.CurrentPage() == pc.TotalPages() {
+		err = io.EOF
+	}
+
+	return err
+}
+
+// TotalPages returns the total number of pages that can returns nodes.
+func (pc *pageCursor) TotalPages() int {
+	pagesf := float64(pc.pagination.Total) / float64(pc.pagination.Limit)
+	pages := int(math.Ceil(pagesf))
+
+	return pages
+}
+
+// CurrentPage returns the current page number the cursor is at.
+func (pc *pageCursor) CurrentPage() int {
+	if pc.pagination.Offset == 0 {
+		return 1
+	}
+
+	return pc.pagination.Offset/pc.pagination.Limit + 1
+}
+
+func newPageCursor(c *Client, path, query string, p *Pagination, orderBy *OrderBy) (*pageCursor, error) {
+	if p == nil {
+		p = NewDefaultPagination()
+	}
+
+	tempPagination := Pagination{
+		Limit:        1,
+		IncludeTotal: true,
+	}
+
+	// make a call to pdb for 1 object to fetch the total number of results for
+	// page calculations in the cursor.
+	if err := getRequest(c, path, query, &tempPagination, orderBy, &[]any{}); err != nil {
+		return nil, fmt.Errorf("failed to get result total from pdb: %w", err)
+	}
+
+	p.Total = tempPagination.Total
+	p.IncludeTotal = true
+
+	pc := &pageCursor{
+		client:     c,
+		path:       path,
+		query:      query,
+		pagination: p,
+		orderBy:    orderBy,
+	}
+
+	return pc, nil
 }

--- a/pkg/puppetdb/pagination.go
+++ b/pkg/puppetdb/pagination.go
@@ -49,8 +49,9 @@ type pageCursor struct {
 	currentPage any
 }
 
-// Next returns a page of nodes and iterates the pagination cursor by the
-// offset. If there are no more results left, the error will be io.EOF.
+// next makes a request for a page of results and iterates the pagination
+// cursor by the offset. If there are no more results left, the error will be
+// io.EOF.
 func (pc *pageCursor) next(response any) error {
 	// this block increases the offset and checks of it's greater than or equal
 	// to the total only if we have already returned a first page.
@@ -60,12 +61,6 @@ func (pc *pageCursor) next(response any) error {
 		if pc.pagination.Offset >= pc.pagination.Total {
 			return io.EOF
 		}
-	} else {
-		if pc.pagination == nil {
-			pc.pagination = NewDefaultPagination()
-		}
-
-		pc.pagination.IncludeTotal = true
 	}
 
 	var err error

--- a/pkg/puppetdb/testdata/facts-page-1-response.json
+++ b/pkg/puppetdb/testdata/facts-page-1-response.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "os",
+    "certname": "1.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "1.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "2.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "2.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "3.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "3.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "4.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "4.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "5.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "5.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  }
+]

--- a/pkg/puppetdb/testdata/facts-page-2-response.json
+++ b/pkg/puppetdb/testdata/facts-page-2-response.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "os",
+    "certname": "6.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "6.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "7.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "7.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "8.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "8.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "9.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "9.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  },
+  {
+    "name": "os",
+    "certname": "10.delivery.puppetlabs.net",
+    "value": "Debian",
+    "environment": "production"
+  },
+  {
+    "name": "uptime_days",
+    "certname": "10.delivery.puppetlabs.net",
+    "value": "1000000 days",
+    "environment": "production"
+  }
+]


### PR DESCRIPTION
This generalizes the pagination cursor a bit and makes it easier to wrap it with more constrained types for some endpoints. I also added a cursor for the facts endpoint since it's often used in conjunction with nodes.