### PR TITLE
pdb client: correct pagination offset

### DIFF
--- a/pkg/puppetdb/common_test.go
+++ b/pkg/puppetdb/common_test.go
@@ -35,9 +35,10 @@ func setupGetResponder(t *testing.T, url, query, responseFilename string) {
 }
 
 type mockPaginatedGetOptions struct {
-	limit         int
-	total         int
-	pageFilenames []string
+	limit             int
+	total             int
+	pageFilenames     []string
+	returnErrorOnPage *int
 }
 
 func setupPaginatedGetResponder(t *testing.T, url, query string, opts mockPaginatedGetOptions) {
@@ -67,6 +68,15 @@ func setupPaginatedGetResponder(t *testing.T, url, query string, opts mockPagina
 
 		if offset > 0 {
 			pageNum = offset / opts.limit
+		}
+
+		if opts.returnErrorOnPage != nil && *opts.returnErrorOnPage == pageNum {
+			response := httpmock.NewBytesResponse(http.StatusInternalServerError, []byte("{\"error\": \"oops\"}"))
+			response.Header.Set("Content-Type", "application/json")
+
+			defer response.Body.Close()
+
+			return response, nil
 		}
 
 		responseBody := pages[pageNum]


### PR DESCRIPTION
Here I'm ensuring the pagination object's offset isn't increased if there is an error when fetching the next page. Before, if the pdb client returned an error from the puppetdb api, it would keep increasing the offset, which would not be correct if the server errors ever resolved and a caller tried calling next on the cursor again.