### PR TITLE
(MAINT) Add token authenticate endpoint

### DIFF
--- a/pkg/rbac/testdata/apidocs/AuthenticateRBACToken-request.json
+++ b/pkg/rbac/testdata/apidocs/AuthenticateRBACToken-request.json
@@ -1,0 +1,4 @@
+{
+  "token": "blah",
+  "update_last_activity?":false
+}

--- a/pkg/rbac/testdata/apidocs/AuthenticateRBACToken-response.json
+++ b/pkg/rbac/testdata/apidocs/AuthenticateRBACToken-response.json
@@ -1,0 +1,5 @@
+{
+  "description": "abc",
+  "role_ids": [1,2,3],
+  "user_id": "abc"
+}

--- a/pkg/rbac/token.go
+++ b/pkg/rbac/token.go
@@ -1,7 +1,8 @@
 package rbac
 
 const (
-	requestAuthTokenURI = "/rbac-api/v1/auth/token" // #nosec - this is the uri to get RBAC tokens
+	requestAuthTokenURI  = "/rbac-api/v1/auth/token"              // #nosec - this is the uri to g et RBAC tokens
+	tokenAuthenticateURI = "/rbac-api/v2/auth/token/authenticate" // #nosec - this is the uri to authenticate RBAC tokens
 )
 
 // GetRBACToken returns an auth token given user/password information
@@ -11,6 +12,27 @@ func (c *Client) GetRBACToken(authRequest *RequestKeys) (*Token, error) {
 		SetResult(&payload).
 		SetBody(authRequest).
 		Post(requestAuthTokenURI)
+	if err != nil {
+		return nil, FormatError(r, err.Error())
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, FormatError(r)
+		}
+		return nil, FormatError(r)
+	}
+	return &payload, nil
+}
+
+// AuthenticateRBACToken returns a response with the token details or errors otherwise.
+func (c *Client) AuthenticateRBACToken(token string) (*AuthenticateResponse, error) {
+	authenticateRequest := &AuthenticateRequest{Token: token}
+
+	payload := AuthenticateResponse{}
+	r, err := c.resty.R().
+		SetResult(&payload).
+		SetBody(authenticateRequest).
+		Post(tokenAuthenticateURI)
 	if err != nil {
 		return nil, FormatError(r, err.Error())
 	}
@@ -36,4 +58,19 @@ type RequestKeys struct {
 	Description string `json:"description,omitempty"`
 	Client      string `json:"client,omitempty"`
 	Label       string `json:"label,omitempty"`
+}
+
+// AuthenticateRequest will hold the request needed for an authenticate.
+type AuthenticateRequest struct {
+	Token              string `json:"token"`
+	UpdateLastActivity bool   `json:"update_last_activity?"`
+}
+
+// AuthenticateResponse will hold the response from an authenticate.
+type AuthenticateResponse struct {
+	Description string `json:"description"`
+	Login       string `json:"login"`
+	RoleIDs     []int  `json:"role_ids"`
+	UserID      string `json:"user_id"`
+	DisplayName string `json:"display_name"`
 }

--- a/pkg/rbac/token_test.go
+++ b/pkg/rbac/token_test.go
@@ -28,3 +28,24 @@ func TestGetRBACToken(t *testing.T) {
 	require.Nil(t, actual)
 	require.Equal(t, expectedError, err)
 }
+
+func TestAuthenticateRBACToken(t *testing.T) {
+	// Test success
+	setupPostResponder(t, tokenAuthenticateURI, "AuthenticateRBACToken-request.json",
+		"AuthenticateRBACToken-response.json")
+
+	expectedResponse := &AuthenticateResponse{
+		UserID:      "abc",
+		Description: "abc",
+		RoleIDs:     []int{1, 2, 3},
+	}
+	actual, err := rbacClient.AuthenticateRBACToken("blah")
+	require.Nil(t, err)
+	require.Equal(t, expectedResponse, actual)
+
+	// Test error
+	setUpBadRequestResponder(t, http.MethodPost, tokenAuthenticateURI)
+	actual, err = rbacClient.AuthenticateRBACToken("blah")
+	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+}


### PR DESCRIPTION
Problem:
We require to check whether a token is valid or not.

Solution:
Add the rbac v2 authenticate API.

Testing:
Tested with unit tests and tested with real PE.