### PR TITLE
(MAINT) Add revoke token ability to RBAC APIs.

### DIFF
--- a/pkg/rbac/client.go
+++ b/pkg/rbac/client.go
@@ -39,6 +39,7 @@ func NewClient(hostURL string, tlsConfig *tls.Config) *Client {
 type APIError struct {
 	Kind       string `json:"kind"`
 	Msg        string `json:"msg"`
+	Details    string `json:"details"`
 	StatusCode int
 }
 

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -30,6 +30,16 @@ func setUpOKResponder(t *testing.T, httpMethod string, path string, responseFile
 	response.Body.Close()
 }
 
+func setUpOKDeleteResponder(path string) {
+	httpmock.Reset()
+
+	response := httpmock.NewStringResponse(http.StatusOK, `{}`)
+	response.Header.Set("Content-Type", "application/json")
+
+	httpmock.RegisterResponder(http.MethodDelete, rbacAPIOrigin+path, httpmock.ResponderFromResponse(response))
+	response.Body.Close()
+}
+
 func setUpBadRequestResponder(t *testing.T, httpMethod string, path string) {
 	httpmock.Reset()
 

--- a/pkg/rbac/token.go
+++ b/pkg/rbac/token.go
@@ -1,8 +1,11 @@
 package rbac
 
+import "fmt"
+
 const (
 	requestAuthTokenURI  = "/rbac-api/v1/auth/token"              // #nosec - this is the uri to g et RBAC tokens
 	tokenAuthenticateURI = "/rbac-api/v2/auth/token/authenticate" // #nosec - this is the uri to authenticate RBAC tokens
+	tokenRevokeURI       = "/rbac-api/v2/tokens/"                 // #nosec - this is the uri to revoke individual RBAC tokens
 )
 
 // GetRBACToken returns an auth token given user/password information
@@ -43,6 +46,24 @@ func (c *Client) AuthenticateRBACToken(token string) (*AuthenticateResponse, err
 		return nil, FormatError(r)
 	}
 	return &payload, nil
+}
+
+func (c *Client) RevokeRBACToken(token string) error {
+	payload := AuthenticateResponse{}
+
+	r, err := c.resty.R().
+		SetResult(&payload).
+		Delete(fmt.Sprintf("%s%s", tokenRevokeURI, token))
+	if err != nil {
+		return FormatError(r, err.Error())
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return FormatError(r)
+		}
+		return FormatError(r)
+	}
+	return nil
 }
 
 // Token is the returned auth token

--- a/pkg/rbac/token_test.go
+++ b/pkg/rbac/token_test.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -47,5 +48,20 @@ func TestAuthenticateRBACToken(t *testing.T) {
 	setUpBadRequestResponder(t, http.MethodPost, tokenAuthenticateURI)
 	actual, err = rbacClient.AuthenticateRBACToken("blah")
 	require.Nil(t, actual)
+	require.Equal(t, expectedError, err)
+}
+
+func TestRevokeRBACToken(t *testing.T) {
+	tokenValue := "abc"
+
+	// Test success
+	setUpOKDeleteResponder(fmt.Sprintf("%s%s", tokenRevokeURI, tokenValue))
+
+	err := rbacClient.RevokeRBACToken(tokenValue)
+	require.Nil(t, err)
+
+	// Test error
+	setUpBadRequestResponder(t, http.MethodDelete, fmt.Sprintf("%s%s", tokenRevokeURI, tokenValue))
+	err = rbacClient.RevokeRBACToken(tokenValue)
 	require.Equal(t, expectedError, err)
 }


### PR DESCRIPTION
Problem:
We have a need to use the revoke token API which PE doesn't have.

Solution:
Add the API as per docs https://www.puppet.com/docs/pe/2021.2/rbac_api_v2_tokens_endpoints#delete_tokens_lt_token_gt

Testing:
Unit testing added and code integrated with business logic and works as expected.

