### PR TITLE
(MAINT) Add the PE v1 /tokens endpoint

### DIFF
--- a/pkg/rbac/testdata/apidocs/GenerateToken-request.json
+++ b/pkg/rbac/testdata/apidocs/GenerateToken-request.json
@@ -1,0 +1,5 @@
+{
+  "lifetime": "1y",
+  "description": "A token to be used with joy and care.",
+  "client": "PE console"
+}

--- a/pkg/rbac/testdata/apidocs/GenerateToken-response.json
+++ b/pkg/rbac/testdata/apidocs/GenerateToken-response.json
@@ -1,0 +1,3 @@
+{
+  "token": "some token"
+}

--- a/pkg/rbac/token_test.go
+++ b/pkg/rbac/token_test.go
@@ -65,3 +65,25 @@ func TestRevokeRBACToken(t *testing.T) {
 	err = rbacClient.RevokeRBACToken(tokenValue)
 	require.Equal(t, expectedError, err)
 }
+
+func TestGenerateRBACToken(t *testing.T) {
+	tokenValue := "some token"
+
+	tokenRequest := TokenRequest{
+		Description: "A token to be used with joy and care.",
+		Lifetime:    "1y",
+		Client:      "PE console",
+	}
+
+	// Test success
+	setupPostResponder(t, tokenGenerateURI, "GenerateToken-request.json", "GenerateToken-response.json")
+
+	tokenResponse, err := rbacClient.GenerateRBACToken(tokenValue, tokenRequest)
+	require.Nil(t, err)
+	require.Equal(t, tokenValue, tokenResponse)
+
+	// Test error
+	setUpBadRequestResponder(t, http.MethodPost, tokenGenerateURI)
+	_, err = rbacClient.GenerateRBACToken(tokenValue, tokenRequest)
+	require.Equal(t, expectedError, err)
+}


### PR DESCRIPTION
Problem:
The API to generate PE tokens from another token is something that could prove very useful in project Comply.

Solution:
Add the API as per PE docs.

Testing:
- Tested with unit tests.
- Included in local code and tested with a real PE. Works as expected.