### PR TITLE
Add PE users endpoints.

### DIFF
--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -17,7 +17,7 @@ func init() {
 	httpmock.ActivateNonDefault(rbacClient.resty.GetClient())
 }
 
-func setUpOKResponder(t *testing.T, httpMethod string, path string, responseFilePath string) {
+func setUpOKResponder(t *testing.T, path string, responseFilePath string) {
 	httpmock.Reset()
 
 	responseBody, err := os.ReadFile(responseFilePath)
@@ -26,7 +26,7 @@ func setUpOKResponder(t *testing.T, httpMethod string, path string, responseFile
 	response := httpmock.NewBytesResponse(http.StatusOK, responseBody)
 	response.Header.Set("Content-Type", "application/json")
 
-	httpmock.RegisterResponder(httpMethod, rbacAPIOrigin+path, httpmock.ResponderFromResponse(response))
+	httpmock.RegisterResponder(http.MethodGet, rbacAPIOrigin+path, httpmock.ResponderFromResponse(response))
 	response.Body.Close()
 }
 

--- a/pkg/rbac/roles_test.go
+++ b/pkg/rbac/roles_test.go
@@ -2,7 +2,6 @@ package rbac
 
 import (
 	"encoding/json"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -26,7 +25,7 @@ func TestGetRoles(t *testing.T) {
 	err = json.NewDecoder(expectedRolesJSONFile).Decode(&expectedRoles)
 	require.Nil(t, err, "error decoding expected roles")
 
-	setUpOKResponder(t, http.MethodGet, rolesPath, getRolesResponseFilePath)
+	setUpOKResponder(t, rolesPath, getRolesResponseFilePath)
 
 	actualRoles, err := rbacClient.GetRoles(token)
 	require.Nil(t, err)
@@ -43,7 +42,7 @@ func TestGetRole(t *testing.T) {
 	require.Nil(t, err, "error decoding expected role")
 
 	rolePathWithID := strings.ReplaceAll(rolePath, "{id}", strconv.Itoa(int(expectedRole.ID)))
-	setUpOKResponder(t, http.MethodGet, rolePathWithID, getRoleResponseFilePath)
+	setUpOKResponder(t, rolePathWithID, getRoleResponseFilePath)
 
 	actualRole, err := rbacClient.GetRole(expectedRole.ID, token)
 	require.Nil(t, err)

--- a/pkg/rbac/testdata/apidocs/GetUser-response.json
+++ b/pkg/rbac/testdata/apidocs/GetUser-response.json
@@ -1,0 +1,10 @@
+{"id": "fe62d770-5886-11e4-8ed6-0800200c9a66",
+  "login": "Amari",
+  "email": "amariperez@example.com",
+  "display_name": "Amari Perez",
+  "role_ids": [1,2,3],
+  "is_group" : false,
+  "is_remote" : false,
+  "is_superuser" : false,
+  "is_revoked": false,
+  "last_login": "2014-05-04T02:32:00Z"}

--- a/pkg/rbac/testdata/apidocs/GetUsers-response.json
+++ b/pkg/rbac/testdata/apidocs/GetUsers-response.json
@@ -1,0 +1,38 @@
+[{
+  "id": "fe62d770-5886-11e4-8ed6-0800200c9a66",
+  "login": "Kalo",
+  "email": "kalohill@example.com",
+  "display_name": "Kalo Hill",
+  "role_ids": [1,2,3],
+  "is_group" : false,
+  "is_remote" : false,
+  "is_superuser" : true,
+  "is_revoked": false,
+  "last_login": "2014-05-04T02:32:00Z"
+},{
+  "id": "07d9c8e0-5887-11e4-8ed6-0800200c9a66",
+  "login": "Jean",
+  "email": "jeanjackson@example.com",
+  "display_name": "Jean Jackson",
+  "role_ids": [2, 3],
+  "inherited_role_ids": [5],
+  "is_group" : false,
+  "is_remote" : true,
+  "is_superuser" : false,
+  "group_ids": ["2ca57e30-5887-11e4-8ed6-0800200c9a66"],
+  "is_revoked": false,
+  "last_login": "2014-05-04T02:32:00Z"
+},{
+  "id": "1cadd0e0-5887-11e4-8ed6-0800200c9a66",
+  "login": "Amari",
+  "email": "amariperez@example.com",
+  "display_name": "Amari Perez",
+  "role_ids": [2, 3],
+  "inherited_role_ids": [5],
+  "is_group" : false,
+  "is_remote" : true,
+  "is_superuser" : false,
+  "group_ids": ["2ca57e30-5887-11e4-8ed6-0800200c9a66"],
+  "is_revoked": false,
+  "last_login": "2014-05-04T02:32:00Z"
+}]

--- a/pkg/rbac/users.go
+++ b/pkg/rbac/users.go
@@ -1,0 +1,86 @@
+package rbac
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	requestUsersURI       = "/users"         // #nosec - this is the uri to g et RBAC tokens
+	requestCurrentUserURI = "/users/current" // #nosec - this is the uri to authenticate RBAC tokens
+	requestUserURI        = "/users/"        // #nosec - this is the uri to revoke individual RBAC tokens
+)
+
+// User describes the user keys.
+type User struct {
+	ID               string    `json:"id"`
+	Login            string    `json:"login"`
+	Email            string    `json:"email,omitempty"`
+	DisplayName      string    `json:"display_name,omitempty"`
+	RoleIDs          []int     `json:"role_ids,omitempty"`
+	IsGroup          bool      `json:"is_group,omitempty"`
+	IsRemote         bool      `json:"is_remote,omitempty"`
+	IsUser           bool      `json:"is_user,omitempty"`
+	IsSuperUser      bool      `json:"is_superuser,omitempty"`
+	IsRevoked        bool      `json:"is_revoked,omitempty"`
+	LastLogin        time.Time `json:"last_login,omitempty"`
+	InheritedRoleIDs []int     `json:"inherited_role_ids,omitempty"`
+	GroupIDs         []string  `json:"group_ids,omitempty"`
+}
+
+// GetUsers returns all the users in the system.
+func (c *Client) GetUsers(token string) ([]User, error) {
+	users := []User{}
+	r, err := c.resty.R().
+		SetHeader("X-Authentication", token).
+		SetResult(&users).
+		Get(requestUsersURI)
+	if err != nil {
+		return nil, FormatError(r, err.Error())
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, FormatError(r)
+		}
+		return nil, FormatError(r)
+	}
+	return users, nil
+}
+
+// GetCurrentUser will return the current user details.
+func (c *Client) GetCurrentUser(token string) (*User, error) {
+	user := User{}
+	r, err := c.resty.R().
+		SetHeader("X-Authentication", token).
+		SetResult(&user).
+		Get(requestCurrentUserURI)
+	if err != nil {
+		return nil, FormatError(r, err.Error())
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, FormatError(r)
+		}
+		return nil, FormatError(r)
+	}
+	return &user, nil
+}
+
+// GetSpecificUser will return a specific user details
+func (c *Client) GetSpecificUser(token string, sid string) (*User, error) {
+	user := User{}
+	r, err := c.resty.R().
+		SetHeader("X-Authentication", token).
+		SetResult(&user).
+		Get(fmt.Sprintf("%s%s", requestUserURI, sid))
+	if err != nil {
+		return nil, FormatError(r, err.Error())
+	}
+	if r.IsError() {
+		if r.Error() != nil {
+			return nil, FormatError(r)
+		}
+		return nil, FormatError(r)
+	}
+	return &user, nil
+}

--- a/pkg/rbac/users_test.go
+++ b/pkg/rbac/users_test.go
@@ -1,0 +1,74 @@
+package rbac
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	getUserResponseFilePath  = "testdata/apidocs/GetUser-response.json"
+	getUsersResponseFilePath = "testdata/apidocs/GetUsers-response.json"
+)
+
+func TestGetUsers(t *testing.T) {
+	var expectedUsers []User
+
+	expectedUsersJSONFile, err := os.Open(getUsersResponseFilePath)
+	require.Nil(t, err, "failed to open expected users JSON file")
+
+	err = json.NewDecoder(expectedUsersJSONFile).Decode(&expectedUsers)
+	require.Nil(t, err, "error decoding expected users")
+
+	setUpOKResponder(t, requestUsersURI, getUsersResponseFilePath)
+
+	actualUsers, err := rbacClient.GetUsers(token)
+	require.Nil(t, err)
+	require.NotNil(t, actualUsers)
+
+	require.Equal(t, len(expectedUsers), len(actualUsers))
+}
+
+func TestGetCurrentUser(t *testing.T) {
+	var expectedUser User
+
+	expectedUserJSONFile, err := os.Open(getUserResponseFilePath)
+	require.Nil(t, err, "failed to open expected user JSON file")
+
+	err = json.NewDecoder(expectedUserJSONFile).Decode(&expectedUser)
+	require.Nil(t, err, "error decoding expected role")
+
+	setUpOKResponder(t, requestCurrentUserURI, getUserResponseFilePath)
+
+	actualUser, err := rbacClient.GetCurrentUser(token)
+	require.Nil(t, err)
+
+	match := reflect.DeepEqual(expectedUser, *actualUser)
+	require.True(t, match, "Expected and actual output do not match.")
+}
+
+func TestGetSpecificUser(t *testing.T) {
+	specificUserID := "specific-user-test"
+
+	var expectedUser User
+
+	expectedUserJSONFile, err := os.Open(getUserResponseFilePath)
+	require.Nil(t, err, "failed to open expected user JSON file")
+
+	err = json.NewDecoder(expectedUserJSONFile).Decode(&expectedUser)
+	require.Nil(t, err, "error decoding expected role")
+
+	specificURI := fmt.Sprintf("%s%s", requestUserURI, specificUserID)
+
+	setUpOKResponder(t, specificURI, getUserResponseFilePath)
+
+	actualUser, err := rbacClient.GetSpecificUser(token, specificUserID)
+	require.Nil(t, err)
+
+	match := reflect.DeepEqual(expectedUser, *actualUser)
+	require.True(t, match, "Expected and actual output do not match.")
+}


### PR DESCRIPTION
Problem:
We have a requirement to use the go-pe-client in order to query specific users, current users and all users.

Solution:
Provide an APi as per the PE docs.

Testing:
Unit testing performed.